### PR TITLE
Add Taskfile

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,40 @@
+---
+# https://taskfile.dev
+
+version: '3'
+
+tasks:
+  build:
+    desc: Build the binary
+    cmds:
+      - |
+        poetry run pyinstaller cook-import \
+            --collect-data mf2py \
+            --collect-data recipe_scrapers \
+            --hidden-import  recipe_scrapers.settings.default  \
+            --onefile
+  clean:
+    desc: Clean the build and dist dirs
+    cmds:
+      - rm -rf ./dist
+      - rm rf ./build
+  deps:
+    desc: Install dependencies using Poetry
+    cmds:
+      - poetry install
+  export:
+    desc: Scrape a recipe from a webpage and output to file
+    cmds:
+      - poetry run ./cook-import --link {{ .URL }} --file
+    vars:
+      URL: https://www.bbcgoodfood.com/recipes/next-level-tikka-masala 
+  run:
+    desc: Scrape a recipe from a webpage and output to screen
+    cmds:
+      - poetry run ./cook-import --link {{ .URL }}
+    vars:
+      URL: https://www.bbcgoodfood.com/recipes/next-level-tikka-masala
+  default:
+    cmds:
+      - task -l
+    silent: true


### PR DESCRIPTION
Signed-off-by: Nicholas Wilde <ncwilde43@gmail.com>

Benefits
- Add support for [go-task](https://taskfile.dev/#/), which is similar to make, to automate common tasks such as build instead of using scripts.

Possible Drawbacks
- None

Related Issues
- N/A