### PR TITLE
Use `link` parameter in `write_to_file`

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -45,7 +45,7 @@ def write_to_file(title, link, total_time, image, instructions):
     @param instructions the instructions for the desired recipe
     """
     with open(f"{title}.cook", "w") as outfile:
-        outfile.write(f">> source: {sys.argv[1]}\n")
+        outfile.write(f">> source: {link}\n")
         outfile.write(f">> time required: {total_time} minutes\n")
         outfile.write(f">> image: {image}\n\n")
         outfile.write(instructions)


### PR DESCRIPTION
Use value of `link` parameter for the recipe source to produce correct metadata. Fixes #16