### PR TITLE
Unify function for output methods

### DIFF
--- a/cook-import
+++ b/cook-import
@@ -7,7 +7,7 @@ import sys
 from recipe_scrapers import scrape_me, WebsiteNotImplementedError
 from parse_ingredients import parse_ingredient
 
-from utils import eprint, sub_lists, write_to_file, highlight_replacement_in_text
+from utils import eprint, sub_lists, print_recipe, highlight_replacement_in_text
 
 
 parser = argparse.ArgumentParser(
@@ -108,4 +108,4 @@ for combined_ingredient in ingredients_list:
 
 instructions = instructions.replace("\n", "\n\n")
 
-write_to_file(title, args.link, total_time, image, instructions, stdout=not(args.file))
+print_recipe(title, args.link, total_time, image, instructions, to_file=args.file)

--- a/cook-import
+++ b/cook-import
@@ -108,12 +108,4 @@ for combined_ingredient in ingredients_list:
 
 instructions = instructions.replace("\n", "\n\n")
 
-if args.file:
-    write_to_file(title, args.link, total_time, image, instructions)
-else:
-    print("")
-    print(f"{title}")
-    print(f">> source: {args.link}")
-    print(f">> time required: {total_time} minutes")
-    print(f">> image: {image}\n")
-    print(instructions)
+write_to_file(title, args.link, total_time, image, instructions, stdout=not(args.file))

--- a/utils.py
+++ b/utils.py
@@ -48,8 +48,7 @@ def write_to_file(title, link, total_time, image, instructions, stdout=False):
         f">> source: {link}",
         f">> time required: {total_time} minutes",
         f">> image: {image}",
-        "\n",
-        instructions,
+        "\n" + instructions,
     ]
     if stdout:
         print("\n".join(recipe))

--- a/utils.py
+++ b/utils.py
@@ -34,7 +34,7 @@ def highlight_replacement_in_text(instructions, match_start, match_end):
     eprint(" " * (3 + match_start - start), "^" * (match_end - match_start))
 
 
-def write_to_file(title, link, total_time, image, instructions, stdout=False):
+def print_recipe(title, link, total_time, image, instructions, to_file=False):
     """
     Write the recipe to a file
     args:
@@ -43,6 +43,7 @@ def write_to_file(title, link, total_time, image, instructions, stdout=False):
     @param total_time the total amount of time for the recipe
     @param image the image associated with the recipe
     @param instructions the instructions for the desired recipe
+    @param to_file write formatted recipe to file instead to stdout
     """
     recipe = [
         f">> source: {link}",
@@ -50,9 +51,8 @@ def write_to_file(title, link, total_time, image, instructions, stdout=False):
         f">> image: {image}",
         "\n" + instructions,
     ]
-    if stdout:
-        print("\n".join(recipe))
-
-    else:
+    if to_file:
         with open(f"{title}.cook", "w") as outfile:
             outfile.write("\n".join(recipe) + "\n")
+    else:
+        print("\n".join(recipe))

--- a/utils.py
+++ b/utils.py
@@ -34,7 +34,7 @@ def highlight_replacement_in_text(instructions, match_start, match_end):
     eprint(" " * (3 + match_start - start), "^" * (match_end - match_start))
 
 
-def write_to_file(title, link, total_time, image, instructions):
+def write_to_file(title, link, total_time, image, instructions, stdout=False):
     """
     Write the recipe to a file
     args:
@@ -44,8 +44,16 @@ def write_to_file(title, link, total_time, image, instructions):
     @param image the image associated with the recipe
     @param instructions the instructions for the desired recipe
     """
-    with open(f"{title}.cook", "w") as outfile:
-        outfile.write(f">> source: {link}\n")
-        outfile.write(f">> time required: {total_time} minutes\n")
-        outfile.write(f">> image: {image}\n\n")
-        outfile.write(instructions)
+    recipe = [
+        f">> source: {link}",
+        f">> time required: {total_time} minutes",
+        f">> image: {image}",
+        "\n",
+        instructions,
+    ]
+    if stdout:
+        print("\n".join(recipe))
+
+    else:
+        with open(f"{title}.cook", "w") as outfile:
+            outfile.write("\n".join(recipe) + "\n")


### PR DESCRIPTION
In order to avoid redundancies in the implementation and to be able to add further metadata fields more easily later on, outputting function was unified, so it uses exact same output for console and for files.
By default, the function will print to stdout.