### PR TITLE
fix: mark amount of ingredient as 0 when amount is not specified.

### DIFF
--- a/cook-import
+++ b/cook-import
@@ -10,7 +10,10 @@ from parse_ingredients import parse_ingredient
 from utils import eprint, sub_lists, print_recipe, highlight_replacement_in_text
 
 # List of single stop words used to remove from ingredient list. Prevents outputs like @onion @powder{1%tbsp}{1%tbsp}
-single_stop_words={"and", "or", "for", "the", "of", "powder", "syrup"}
+single_stop_words={"and", "or", "for", "the", "of", "powder", "syrup", "pinch", "cheese", "ground", "powdered", "seeds"}
+
+# List of small amount types to convert quantity from 0 to 1.
+small_amount_words={"dash", "pinch", "sprinkle", "smidgen", "drop", "bunch"}
 
 parser = argparse.ArgumentParser(
     description="Automatically extract recipes from online websites."
@@ -70,7 +73,11 @@ for combined_ingredient in ingredients_list:
     # Truncate repeating decimals such as .333333
     if len(str(quantity)) > 5:
         quantity = f"{quantity:.2f}"
-          
+
+    # Unit is a small amount word and quantity is 0
+    if ((unit in small_amount_words) and (quantity==0)):
+        quantity = 1
+
     # remove extra characters aka ')'
     ingredient_fixed = re.sub(r" ?\)", "", combined_ingredient.name)
 
@@ -82,9 +89,10 @@ for combined_ingredient in ingredients_list:
     ing_list = list(filter(lambda x: len(x) > 0, ing_list))
 
     # Remove single stop words
-    ing_list = list(
-        filter(lambda x: x[0] not in single_stop_words, ing_list)
-    )
+    if len(ing_list) > 1:
+        ing_list = list(
+            filter(lambda x: x[0] not in single_stop_words, ing_list)
+        )
 
     # Now generate regex string to  match
     ing_list = sorted(ing_list, reverse=True, key=lambda x: len(x))
@@ -96,7 +104,7 @@ for combined_ingredient in ingredients_list:
     eprint("")
     eprint(
         "✅" if match_obj is not None else "❌",
-        f"@{combined_ingredient.name}{{{quantity}%{unit}}}" if unit != "" else f"@{combined_ingredient.name}{{{quantity}}}"
+        f"@{combined_ingredient.name}{{{quantity}%{unit}}}" if unit != "" else (f"@{combined_ingredient.name}{{}}" if quantity==0 else f"@{combined_ingredient.name}{{{quantity}}}")
     )
 
     # If no match skip ingredient
@@ -107,7 +115,7 @@ for combined_ingredient in ingredients_list:
     match_end = match_obj.end(1)
 
     highlight_replacement_in_text(instructions, match_start, match_end)
-    ing_replacement = f"@{match_obj[1]}{{{quantity}%{unit}}}" if unit != "" else f"@{match_obj[1]}{{{quantity}}}"
+    ing_replacement = f"@{match_obj[1]}{{{quantity}%{unit}}}" if unit != "" else (f"@{match_obj[1]}{{}}" if quantity==0 else f"@{match_obj[1]}{{{quantity}}}")
     instructions = (
         instructions[0:match_start]
         + ing_replacement


### PR DESCRIPTION
### Change description

- When an ingredient has a quantity of 0, remove the quantity from the ingredient, such as `@salt{}`.
- Add "pinch", "cheese", "ground", "powdered", "seeds" to single_stop_words.
- Add `small_amount_words` list to convert certain unit quantities from 0 to 1, such as `@salt{1%pinch}`.
- Check if list length is greater than 1 for `single_stop_words` filter.

### Related issues

- Fixes #22

### Additional information

N/A
