### PR TITLE
Handle image links in JSON-LD recipe imports

### DIFF
--- a/src/extractors/json_ld.rs
+++ b/src/extractors/json_ld.rs
@@ -130,9 +130,7 @@ impl JsonLdExtractor {
                     Some(decode_html_symbols(&imgs[0]))
                 }
                 ImageType::Object(i) => Some(i.url.clone()),
-                ImageType::MultipleObjects(imgs) if !imgs.is_empty() => {
-                    Some(imgs[0].url.clone())
-                }
+                ImageType::MultipleObjects(imgs) if !imgs.is_empty() => Some(imgs[0].url.clone()),
                 _ => None,
             };
             if let Some(url) = image_url {


### PR DESCRIPTION
When importing recipes from JSON-LD format, extract the image URL from the recipe data and add it to the YAML frontmatter with the key "image". If multiple images are available, use the first one.

The image is extracted and decoded using the existing HTML entity decoding, and added to the metadata HashMap that generates the YAML frontmatter.