### PR TITLE
feat: Add Cloudflare bypass test and enable `native-tls-alpn` feature…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ env_logger = "0.11"
 html-escape = "0.2"
 log = "0.4"
 openssl = { version = "0.10", features = ["vendored"] }
-reqwest = { version = "0.12", features = ["blocking", "json", "native-tls-vendored"] }
+reqwest = { version = "0.12", features = ["blocking", "json", "native-tls-vendored", "native-tls-alpn"] }
 scraper = "0.20"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/tests/test_cloudflare_bypass.rs
+++ b/tests/test_cloudflare_bypass.rs
@@ -1,0 +1,36 @@
+use cooklang_import::fetch_recipe;
+use std::env;
+
+#[tokio::test]
+#[ignore] // This test requires network access and is subject to external site changes
+async fn test_acouplecooks_cloudflare_bypass() {
+    // Enable logging to see debug output if needed
+    env::set_var("RUST_LOG", "debug");
+    let _ = env_logger::try_init();
+
+    let url = "https://www.acouplecooks.com/apple-cranberry-crisp/";
+
+    println!("Attempting to fetch recipe from: {}", url);
+
+    match fetch_recipe(url).await {
+        Ok(recipe) => {
+            println!("Successfully bypassed Cloudflare and parsed recipe!");
+            println!("Name: {}", recipe.name);
+
+            // Verify we got the correct recipe
+            assert_eq!(recipe.name, "Apple Cranberry Crisp");
+            assert!(!recipe.content.is_empty());
+
+            // Verify some specific content to ensure we didn't just get a title from metadata
+            assert!(recipe.content.contains("cranberries"));
+            assert!(recipe.content.contains("sugar"));
+
+            // Check metadata
+            assert_eq!(recipe.metadata.get("author").unwrap(), "Sonja Overhiser");
+            assert!(recipe.metadata.contains_key("cook time"));
+        }
+        Err(e) => {
+            panic!("Failed to fetch recipe (Cloudflare bypass failed?): {}", e);
+        }
+    }
+}


### PR DESCRIPTION
# The Issue
The website is protected by Cloudflare, which was blocking the default reqwest HTTP client used by the application. This resulted in the application receiving a "Just a moment..." challenge page instead of the actual recipe content, causing the JSON-LD extractor to fail.

# The Fix
The root cause was identified as a known issue with reqwest's default TLS configuration when interacting with Cloudflare's HTTP/2 implementation. The fix involved:

Enabling native-tls-alpn: This feature ensures correct Application-Layer Protocol Negotiation (ALPN) for HTTP/2, which Cloudflare requires to validate the client.

# Changes
Cargo.toml
Enabled native-tls-alpn feature for reqwest.

```
reqwest = { version = "0.12", features = ["blocking", "json", "native-tls-vendored", "native-tls-alpn"] }
```

# Verification
I verified the fix by running the application against the reported URL:

```
cargo run https://www.acouplecooks.com/apple-cranberry-crisp/
```

**Result**: The application successfully extracted the recipe.

## Automated Test
I also added a new integration test `tests/test_cloudflare_bypass.rs` to ensure this remains fixed. You can run it with:

```
cargo test --test test_cloudflare_bypass -- --ignored
```