### PR TITLE
feat: add MicroData extractor for recipe parsing and integrate it int…

### DIFF
--- a/src/extractors/microdata.rs
+++ b/src/extractors/microdata.rs
@@ -1,0 +1,193 @@
+use crate::extractors::{Extractor, ParsingContext};
+use crate::model::Recipe;
+use log::debug;
+use scraper::{ElementRef, Selector};
+use std::collections::HashMap;
+
+pub struct MicroDataExtractor;
+
+impl MicroDataExtractor {
+    fn find_recipe_container<'a>(&self, document: &'a scraper::Html) -> Option<ElementRef<'a>> {
+        // Look for elements with itemscope and itemtype containing "Recipe"
+        let selector = Selector::parse("[itemscope]").unwrap();
+        for element in document.select(&selector) {
+            if let Some(itemtype) = element.value().attr("itemtype") {
+                if itemtype.contains("schema.org/Recipe")
+                    || itemtype.contains("data-vocabulary.org/Recipe")
+                {
+                    return Some(element);
+                }
+            }
+        }
+        None
+    }
+
+    fn get_itemprop(&self, root: ElementRef, prop: &str) -> Option<String> {
+        let selector = Selector::parse(&format!("[itemprop='{}']", prop)).unwrap();
+        root.select(&selector)
+            .next()
+            .map(|el| el.text().collect::<Vec<_>>().join(" ").trim().to_string())
+    }
+
+    fn get_itemprop_list(&self, root: ElementRef, prop: &str) -> Vec<String> {
+        let mut items = Vec::new();
+        let selector = Selector::parse(&format!("[itemprop='{}']", prop)).unwrap();
+        for el in root.select(&selector) {
+            let text = el.text().collect::<Vec<_>>().join(" ").trim().to_string();
+            if !text.is_empty() {
+                items.push(text);
+            }
+        }
+        items
+    }
+}
+
+impl Extractor for MicroDataExtractor {
+    fn parse(&self, context: &ParsingContext) -> Result<Recipe, Box<dyn std::error::Error>> {
+        debug!("Attempting to extract recipe using MicroData extractor");
+
+        let container = self.find_recipe_container(&context.document);
+
+        // We strictly enforce finding a Recipe container to avoid false positives.
+        // Global searches for 'itemprop' (like "name" or "description") often pick up
+        // unrelated page content (site title, author bio, ads, etc.) if not scoped
+        // to a specific Schema.org Recipe item.
+        if container.is_none() {
+            return Err("No MicroData Recipe container found".into());
+        }
+        let container = container.unwrap();
+
+        let mut metadata = HashMap::new();
+        let name;
+        let mut description = None;
+
+        // Name
+        if let Some(n) = self.get_itemprop(container, "name") {
+            name = n;
+        } else {
+            return Err("Could not extract recipe name".into());
+        }
+
+        // Description
+        if let Some(desc) = self.get_itemprop(container, "description") {
+            description = Some(desc);
+        }
+
+        // Image
+        // Try 'image' itemprop, check src attribute if it's an img tag
+        let image_selector = Selector::parse("[itemprop='image']").unwrap();
+        if let Some(img_el) = container.select(&image_selector).next() {
+            if let Some(src) = img_el.value().attr("src") {
+                metadata.insert("image".to_string(), src.to_string());
+            } else {
+                let text = img_el
+                    .text()
+                    .collect::<Vec<_>>()
+                    .join(" ")
+                    .trim()
+                    .to_string();
+                if !text.is_empty() {
+                    metadata.insert("image".to_string(), text);
+                }
+            }
+        }
+
+        // Author
+        // Author can be a string or a Person object
+        let author_selector = Selector::parse("[itemprop='author']").unwrap();
+        if let Some(author_el) = container.select(&author_selector).next() {
+            // Check if it has nested name, otherwise use the author element itself
+            let name_selector = Selector::parse("[itemprop='name']").unwrap();
+            let target_el = author_el.select(&name_selector).next().unwrap_or(author_el);
+
+            let text = target_el
+                .text()
+                .collect::<Vec<_>>()
+                .join(" ")
+                .trim()
+                .to_string();
+
+            if !text.is_empty() {
+                metadata.insert("author".to_string(), text);
+            }
+        }
+
+        // Times
+        if let Some(prep) = self.get_itemprop(container, "prepTime") {
+            metadata.insert("prep_time".to_string(), prep);
+        }
+        if let Some(cook) = self.get_itemprop(container, "cookTime") {
+            metadata.insert("cook_time".to_string(), cook);
+        }
+        if let Some(total) = self.get_itemprop(container, "totalTime") {
+            metadata.insert("total_time".to_string(), total);
+        }
+
+        // Yield/Servings
+        if let Some(yield_val) = self.get_itemprop(container, "recipeYield") {
+            metadata.insert("servings".to_string(), yield_val);
+        }
+
+        // Course / Category
+        if let Some(category) = self.get_itemprop(container, "recipeCategory") {
+            metadata.insert("course".to_string(), category);
+        }
+
+        // Cuisine
+        if let Some(cuisine) = self.get_itemprop(container, "recipeCuisine") {
+            metadata.insert("cuisine".to_string(), cuisine);
+        }
+
+        // Diet
+        if let Some(diet) = self.get_itemprop(container, "suitableForDiet") {
+            metadata.insert("diet".to_string(), diet);
+        }
+
+        // Keywords / Tags
+        if let Some(keywords) = self.get_itemprop(container, "keywords") {
+            metadata.insert("tags".to_string(), keywords);
+        }
+
+        // Ingredients
+        // Try 'ingredients' and 'recipeIngredients'
+        let mut ingredients = self.get_itemprop_list(container, "ingredients");
+        if ingredients.is_empty() {
+            ingredients = self.get_itemprop_list(container, "recipeIngredient");
+        }
+
+        // Instructions
+        // Try 'recipeInstructions' and 'instructions'
+        let mut instructions = self.get_itemprop_list(container, "recipeInstructions");
+        if instructions.is_empty() {
+            instructions = self.get_itemprop_list(container, "instructions");
+        }
+
+        // Validation
+        if ingredients.is_empty() && instructions.is_empty() {
+            return Err("Could not extract recipe content".into());
+        }
+
+        // Combine content
+        let ingredients_str = ingredients.join("\n");
+        let instructions_str = instructions.join("\n");
+
+        let content = if !ingredients_str.is_empty() && !instructions_str.is_empty() {
+            format!("{}\n\n{}", ingredients_str, instructions_str)
+        } else if !ingredients_str.is_empty() {
+            ingredients_str
+        } else {
+            instructions_str
+        };
+
+        // Add source URL
+        metadata.insert("source_url".to_string(), context.url.clone());
+
+        Ok(Recipe {
+            name,
+            description,
+            image: Vec::new(),
+            content,
+            metadata,
+        })
+    }
+}

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -3,10 +3,12 @@ use scraper::Html;
 
 mod html_class;
 mod json_ld;
+mod microdata;
 mod plain_text_llm;
 
 pub use self::html_class::HtmlClassExtractor;
 pub use self::json_ld::JsonLdExtractor;
+pub use self::microdata::MicroDataExtractor;
 pub use self::plain_text_llm::PlainTextLlmExtractor;
 
 pub struct ParsingContext {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ pub async fn fetch_recipe_with_timeout(
 
     let extractors_list: Vec<Box<dyn Extractor>> = vec![
         Box::new(extractors::JsonLdExtractor),
+        Box::new(extractors::MicroDataExtractor),
         Box::new(extractors::HtmlClassExtractor),
         Box::new(extractors::PlainTextLlmExtractor),
     ];

--- a/tests/test_microdata.rs
+++ b/tests/test_microdata.rs
@@ -1,0 +1,134 @@
+#[cfg(test)]
+mod tests {
+    use cooklang_import::extractors::MicroDataExtractor;
+    use cooklang_import::extractors::{Extractor, ParsingContext};
+    use scraper::Html;
+
+    #[test]
+    fn test_microdata_extraction() {
+        let html = r#"
+        <html>
+        <body>
+        <div id="easyrecipe-557-0" class="easyrecipe" itemscope itemtype="http://schema.org/Recipe">
+            <div itemprop="name" class="ERSName">Mom's Famous Banana Bread</div>
+            <div itemprop="description" class="ERSSummary">Mom was kind enough to share her famous banana bread recipe with us!</div>
+            <img itemprop="image" src="https://example.com/banana-bread.jpg" />
+            <div itemprop="author" itemscope itemtype="http://schema.org/Person">
+                <span itemprop="name">Cooking Divine</span>
+            </div>
+            <div itemprop="recipeCategory">Breakfast</div>
+            <div itemprop="recipeCuisine">American</div>
+            <div itemprop="keywords">banana, bread, sweet</div>
+            <div itemprop="suitableForDiet">Vegetarian</div>
+            
+            <div class="ERSTimes">
+                <div class="ERSTime">
+                    <div class="ERSTimeHeading">Prep time</div>
+                    <div class="ERSTimeItem">
+                        <time itemprop="prepTime" datetime="PT10M">10 mins</time>
+                    </div>
+                </div>
+                <div class="ERSTime ERSTimeRight">
+                    <div class="ERSTimeHeading">Cook time</div>
+                    <div class="ERSTimeItem">
+                        <time itemprop="cookTime" datetime="PT1H">1 hour</time>
+                    </div>
+                </div>
+                <div class="ERSTime ERSTimeRight">
+                    <div class="ERSTimeHeading">Total time</div>
+                    <div class="ERSTimeItem">
+                        <time itemprop="totalTime" datetime="PT1H10M">1 hour 10 mins</time>
+                    </div>
+                </div>
+            </div>
+
+            <div class="divERSHeadItems">
+                <div class="ERSServes">Serves: <span itemprop="recipeYield">12 servings</span></div>
+            </div>
+
+            <div class="ERSIngredients">
+                <div class="ERSIngredientsHeader ERSHeading">Ingredients</div>
+                <ul>
+                    <li class="ingredient" itemprop="ingredients">5 Tablespoons Butter (room temperature)</li>
+                    <li class="ingredient" itemprop="ingredients">1 Cup White Sugar</li>
+                    <li class="ingredient" itemprop="ingredients">1 Large Egg</li>
+                </ul>
+            </div>
+
+            <div class="ERSInstructions">
+                <div class="ERSInstructionsHeader ERSHeading">Directions</div>
+                <ol>
+                    <li class="instruction" itemprop="recipeInstructions">Preheat oven to 350 degrees and heavily grease a 9 inch bread pan.</li>
+                    <li class="instruction" itemprop="recipeInstructions">Beat butter and sugar until light, fluffy and well blended.</li>
+                </ol>
+            </div>
+        </div>
+        </body>
+        </html>
+        "#;
+
+        let context = ParsingContext {
+            url: "https://www.cookingdivine.com/recipes/banana-bread/".to_string(),
+            document: Html::parse_document(html),
+            texts: None,
+        };
+
+        let extractor = MicroDataExtractor;
+        let result = extractor.parse(&context);
+
+        assert!(result.is_ok(), "Failed to extract recipe");
+        let recipe = result.unwrap();
+
+        assert_eq!(recipe.name, "Mom's Famous Banana Bread");
+        assert_eq!(
+            recipe.description,
+            Some(
+                "Mom was kind enough to share her famous banana bread recipe with us!".to_string()
+            )
+        );
+
+        assert!(recipe.content.contains("5 Tablespoons Butter"));
+        assert!(recipe.content.contains("1 Cup White Sugar"));
+        assert!(recipe.content.contains("Preheat oven to 350 degrees"));
+
+        assert_eq!(
+            recipe.metadata.get("prep_time"),
+            Some(&"10 mins".to_string())
+        );
+        assert_eq!(
+            recipe.metadata.get("cook_time"),
+            Some(&"1 hour".to_string())
+        );
+        assert_eq!(
+            recipe.metadata.get("total_time"),
+            Some(&"1 hour 10 mins".to_string())
+        );
+        assert_eq!(
+            recipe.metadata.get("servings"),
+            Some(&"12 servings".to_string())
+        );
+
+        // New fields
+        assert_eq!(
+            recipe.metadata.get("author"),
+            Some(&"Cooking Divine".to_string())
+        );
+        assert_eq!(
+            recipe.metadata.get("image"),
+            Some(&"https://example.com/banana-bread.jpg".to_string())
+        );
+        assert_eq!(
+            recipe.metadata.get("course"),
+            Some(&"Breakfast".to_string())
+        );
+        assert_eq!(
+            recipe.metadata.get("cuisine"),
+            Some(&"American".to_string())
+        );
+        assert_eq!(recipe.metadata.get("diet"), Some(&"Vegetarian".to_string()));
+        assert_eq!(
+            recipe.metadata.get("tags"),
+            Some(&"banana, bread, sweet".to_string())
+        );
+    }
+}


### PR DESCRIPTION
# Support for EasyRecipe Format

I have implemented support for the "EasyRecipe" format, which is used by sites like `cookingdivine.com`.

## Changes

### Extractors

#### [NEW] [src/extractors/microdata.rs](file:///Users/evanstern/projects/cooklang/cooklang-import/src/extractors/microdata.rs)
- Implemented [MicroDataExtractor](cci:2://file:///Users/evanstern/projects/cooklang/cooklang-import/src/extractors/microdata.rs:6:0-6:30) which uses [itemprop](cci:1://file:///Users/evanstern/projects/cooklang/cooklang-import/src/extractors/microdata.rs:24:4-29:5) selectors within a `schema.org/Recipe` container.
- Extracts:
    - Name
    - Description
    - Image
    - Author
    - Prep/Cook/Total times
    - Servings (recipeYield)
    - Course (recipeCategory)
    - Cuisine (recipeCuisine)
    - Diet (suitableForDiet)
    - Tags (keywords)
    - Ingredients (supports `ingredients` and `recipeIngredient`)
    - Instructions (supports `recipeInstructions` and `instructions`)
- **Design Decision**: Enforced `itemscope` and `itemtype="http://schema.org/Recipe"` container check to avoid false positives from other schema types on the page.

#### [MODIFY] [src/extractors/mod.rs](file:///Users/evanstern/projects/cooklang/cooklang-import/src/extractors/mod.rs)
- Registered [MicroDataExtractor](cci:2://file:///Users/evanstern/projects/cooklang/cooklang-import/src/extractors/microdata.rs:6:0-6:30) in the main extractor module.

#### [MODIFY] [src/lib.rs](file:///Users/evanstern/projects/cooklang/cooklang-import/src/lib.rs)
- Added [MicroDataExtractor](cci:2://file:///Users/evanstern/projects/cooklang/cooklang-import/src/extractors/microdata.rs:6:0-6:30) to the list of extractors in [fetch_recipe_with_timeout](cci:1://file:///Users/evanstern/projects/cooklang/cooklang-import/src/lib.rs:41:0-108:1), prioritizing it before [HtmlClassExtractor](cci:2://file:///Users/evanstern/projects/cooklang/cooklang-import/src/extractors/html_class.rs:6:0-6:30).

## Verification Results

### Automated Tests
- Renamed [tests/test_easyrecipe.rs](cci:7://file:///Users/evanstern/projects/cooklang/cooklang-import/tests/test_easyrecipe.rs:0:0-0:0) to [tests/test_microdata.rs](cci:7://file:///Users/evanstern/projects/cooklang/cooklang-import/tests/test_microdata.rs:0:0-0:0) and updated it to use `MicroDataExtractor`.
- Ran `cargo test --test test_microdata` which passed successfully.

```bash
running 1 test
test tests::test_microdata_extraction ... ok
```

Reference #28 