### PR TITLE
Add UniFFI bindings for iOS and Android

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,356 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (skip release creation)'
+        required: false
+        default: 'false'
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Build iOS artifacts on macOS
+  build-ios:
+    name: Build iOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-ios-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-ios-cargo-
+
+      - name: Install uniffi-bindgen
+        run: |
+          if ! command -v uniffi-bindgen &> /dev/null; then
+            cargo install uniffi-bindgen-cli --version 0.28
+          fi
+
+      - name: Build iOS targets
+        run: |
+          cargo build --release --target aarch64-apple-ios --features uniffi
+          cargo build --release --target aarch64-apple-ios-sim --features uniffi
+          cargo build --release --target x86_64-apple-ios --features uniffi
+
+      - name: Generate Swift bindings
+        run: |
+          mkdir -p target/ios/swift
+          uniffi-bindgen generate \
+            --library target/aarch64-apple-ios/release/libcooklang_import.a \
+            --language swift \
+            --out-dir target/ios/swift
+
+      - name: Create XCFramework
+        run: |
+          mkdir -p target/ios/ios-device target/ios/ios-simulator
+
+          # Copy device library
+          cp target/aarch64-apple-ios/release/libcooklang_import.a target/ios/ios-device/
+
+          # Create fat library for simulator
+          lipo -create \
+            target/aarch64-apple-ios-sim/release/libcooklang_import.a \
+            target/x86_64-apple-ios/release/libcooklang_import.a \
+            -output target/ios/ios-simulator/libcooklang_import.a
+
+          # Create headers
+          mkdir -p target/ios/ios-device/Headers target/ios/ios-simulator/Headers
+          cp target/ios/swift/cooklang_importFFI.h target/ios/ios-device/Headers/
+          cp target/ios/swift/cooklang_importFFI.h target/ios/ios-simulator/Headers/
+
+          # Create module maps
+          mkdir -p target/ios/ios-device/Modules target/ios/ios-simulator/Modules
+          echo 'module CooklangImportFFI { header "cooklang_importFFI.h" export * }' > target/ios/ios-device/Modules/module.modulemap
+          echo 'module CooklangImportFFI { header "cooklang_importFFI.h" export * }' > target/ios/ios-simulator/Modules/module.modulemap
+
+          # Create XCFramework
+          xcodebuild -create-xcframework \
+            -library target/ios/ios-device/libcooklang_import.a \
+            -headers target/ios/ios-device/Headers \
+            -library target/ios/ios-simulator/libcooklang_import.a \
+            -headers target/ios/ios-simulator/Headers \
+            -output target/ios/CooklangImportFFI.xcframework
+
+      - name: Create Swift Package
+        run: |
+          mkdir -p target/ios/CooklangImport/Sources/CooklangImport
+          cp target/ios/swift/cooklang_import.swift target/ios/CooklangImport/Sources/CooklangImport/
+          cp -R target/ios/CooklangImportFFI.xcframework target/ios/CooklangImport/
+
+          cat > target/ios/CooklangImport/Package.swift << 'EOF'
+          // swift-tools-version:5.5
+          import PackageDescription
+
+          let package = Package(
+              name: "CooklangImport",
+              platforms: [
+                  .iOS(.v13),
+                  .macOS(.v10_15)
+              ],
+              products: [
+                  .library(
+                      name: "CooklangImport",
+                      targets: ["CooklangImport", "CooklangImportFFI"]
+                  ),
+              ],
+              targets: [
+                  .target(
+                      name: "CooklangImport",
+                      dependencies: ["CooklangImportFFI"]
+                  ),
+                  .binaryTarget(
+                      name: "CooklangImportFFI",
+                      path: "CooklangImportFFI.xcframework"
+                  ),
+              ]
+          )
+          EOF
+
+      - name: Package iOS artifacts
+        run: |
+          cd target/ios
+          zip -r ../../cooklang-import-ios.zip CooklangImport CooklangImportFFI.xcframework swift
+
+      - name: Upload iOS artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-artifacts
+          path: cooklang-import-ios.zip
+
+  # Build Android artifacts on Linux
+  build-android:
+    name: Build Android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-android-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-android-cargo-
+
+      - name: Setup Android NDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install NDK
+        run: |
+          sdkmanager --install "ndk;26.1.10909125"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/26.1.10909125" >> $GITHUB_ENV
+
+      - name: Install cargo-ndk and uniffi-bindgen
+        run: |
+          cargo install cargo-ndk || true
+          cargo install uniffi-bindgen-cli --version 0.28 || true
+
+      - name: Build Android targets
+        run: |
+          cargo ndk --target aarch64-linux-android --platform 21 build --release --features uniffi
+          cargo ndk --target armv7-linux-androideabi --platform 21 build --release --features uniffi
+          cargo ndk --target x86_64-linux-android --platform 21 build --release --features uniffi
+          cargo ndk --target i686-linux-android --platform 21 build --release --features uniffi
+
+      - name: Generate Kotlin bindings
+        run: |
+          mkdir -p target/android/kotlin
+          uniffi-bindgen generate \
+            --library target/aarch64-linux-android/release/libcooklang_import.so \
+            --language kotlin \
+            --out-dir target/android/kotlin
+
+      - name: Organize JNI libraries
+        run: |
+          mkdir -p target/android/jniLibs/{arm64-v8a,armeabi-v7a,x86_64,x86}
+          cp target/aarch64-linux-android/release/libcooklang_import.so target/android/jniLibs/arm64-v8a/
+          cp target/armv7-linux-androideabi/release/libcooklang_import.so target/android/jniLibs/armeabi-v7a/
+          cp target/x86_64-linux-android/release/libcooklang_import.so target/android/jniLibs/x86_64/
+          cp target/i686-linux-android/release/libcooklang_import.so target/android/jniLibs/x86/
+
+      - name: Create Android library module
+        run: |
+          mkdir -p target/android/cooklang-import-android/src/main/kotlin
+          mkdir -p target/android/cooklang-import-android/src/main/jniLibs
+
+          # Copy JNI libs
+          cp -R target/android/jniLibs/* target/android/cooklang-import-android/src/main/jniLibs/
+
+          # Copy Kotlin bindings
+          cp target/android/kotlin/*.kt target/android/cooklang-import-android/src/main/kotlin/
+
+          # Create build.gradle.kts
+          cat > target/android/cooklang-import-android/build.gradle.kts << 'EOF'
+          plugins {
+              id("com.android.library")
+              id("org.jetbrains.kotlin.android")
+          }
+
+          android {
+              namespace = "com.cooklang.import_lib"
+              compileSdk = 34
+
+              defaultConfig {
+                  minSdk = 21
+                  testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+                  consumerProguardFiles("consumer-rules.pro")
+              }
+
+              buildTypes {
+                  release {
+                      isMinifyEnabled = false
+                      proguardFiles(
+                          getDefaultProguardFile("proguard-android-optimize.txt"),
+                          "proguard-rules.pro"
+                      )
+                  }
+              }
+              compileOptions {
+                  sourceCompatibility = JavaVersion.VERSION_1_8
+                  targetCompatibility = JavaVersion.VERSION_1_8
+              }
+              kotlinOptions {
+                  jvmTarget = "1.8"
+              }
+              sourceSets {
+                  getByName("main") {
+                      jniLibs.srcDirs("src/main/jniLibs")
+                  }
+              }
+          }
+
+          dependencies {
+              implementation("net.java.dev.jna:jna:5.14.0@aar")
+              implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+          }
+          EOF
+
+          # Create AndroidManifest.xml
+          mkdir -p target/android/cooklang-import-android/src/main
+          cat > target/android/cooklang-import-android/src/main/AndroidManifest.xml << 'EOF'
+          <?xml version="1.0" encoding="utf-8"?>
+          <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+              <uses-permission android:name="android.permission.INTERNET" />
+          </manifest>
+          EOF
+
+          # Create proguard rules
+          cat > target/android/cooklang-import-android/proguard-rules.pro << 'EOF'
+          -keep class uniffi.** { *; }
+          -keep class com.cooklang.** { *; }
+          -keep class com.sun.jna.** { *; }
+          -keepclassmembers class * extends com.sun.jna.** { public *; }
+          EOF
+
+          cat > target/android/cooklang-import-android/consumer-rules.pro << 'EOF'
+          -keep class uniffi.** { *; }
+          -keep class com.cooklang.** { *; }
+          EOF
+
+      - name: Package Android artifacts
+        run: |
+          cd target/android
+          zip -r ../../cooklang-import-android.zip cooklang-import-android jniLibs kotlin
+
+      - name: Upload Android artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-artifacts
+          path: cooklang-import-android.zip
+
+  # Create GitHub Release
+  release:
+    name: Create Release
+    needs: [build-ios, build-android]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && github.event.inputs.dry_run != 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Download iOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-artifacts
+
+      - name: Download Android artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: android-artifacts
+
+      - name: Get version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: Release ${{ steps.version.outputs.VERSION }}
+          draft: false
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}
+          generate_release_notes: true
+          files: |
+            cooklang-import-ios.zip
+            cooklang-import-android.zip
+          body: |
+            ## Mobile SDK Release ${{ steps.version.outputs.VERSION }}
+
+            ### iOS
+            Download `cooklang-import-ios.zip` which contains:
+            - `CooklangImport/` - Swift Package ready to use
+            - `CooklangImportFFI.xcframework` - XCFramework for manual integration
+            - `swift/` - Swift bindings source files
+
+            ### Android
+            Download `cooklang-import-android.zip` which contains:
+            - `cooklang-import-android/` - Android library module
+            - `jniLibs/` - Native libraries for all architectures
+            - `kotlin/` - Kotlin bindings source files
+
+            ### Supported Architectures
+
+            **iOS:**
+            - arm64 (devices)
+            - arm64 (simulator, Apple Silicon)
+            - x86_64 (simulator, Intel)
+
+            **Android:**
+            - arm64-v8a
+            - armeabi-v7a
+            - x86_64
+            - x86
+
+            See the README for integration instructions.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run cargo check
         run: cargo check
 
+      - name: Run cargo check (with uniffi)
+        run: cargo check --features uniffi
+
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -52,6 +55,9 @@ jobs:
 
       - name: Run cargo test
         run: cargo test
+
+      - name: Run cargo test (with uniffi)
+        run: cargo test --features uniffi
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,10 +95,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -161,6 +208,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +260,38 @@ name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+
+[[package]]
+name = "camino"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "cc"
@@ -242,7 +339,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.8.23",
  "yaml-rust2",
 ]
 
@@ -293,6 +390,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "uniffi",
 ]
 
 [[package]]
@@ -506,6 +604,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +718,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +777,12 @@ checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "html-escape"
@@ -1063,6 +1193,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1555,12 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "ppv-lite86"
@@ -1688,6 +1840,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,19 +1902,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.216"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1845,6 +2037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +2063,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -1975,6 +2179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,6 +2290,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -2160,6 +2382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2176,6 +2404,134 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "uniffi"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "serde",
+ "textwrap",
+ "toml 0.5.11",
+ "uniffi_meta",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi_checksum_derive"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "log",
+ "once_cell",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+dependencies = [
+ "bincode",
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml 0.5.11",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "siphasher",
+ "uniffi_checksum_derive",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "uniffi_testing",
+ "weedle2",
+]
 
 [[package]]
 name = "untrusted"
@@ -2326,6 +2682,15 @@ checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,15 @@ homepage = "https://github.com/cooklang/cooklang-import"
 [lib]
 name = "cooklang_import"
 path = "src/lib.rs"
+crate-type = ["lib", "cdylib", "staticlib"]
 
 [[bin]]
 name = "cooklang-import"
 path = "src/main.rs"
+
+[features]
+default = []
+uniffi = ["dep:uniffi"]
 
 [dependencies]
 async-trait = "0.1.83"
@@ -30,7 +35,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.0", features = ["full"] }
+uniffi = { version = "0.28", optional = true }
 
 [dev-dependencies]
 mockito = "1.5.0"
 tokio = { version = "1.0", features = ["full", "rt", "macros", "test-util"] }
+
+[build-dependencies]
+uniffi = { version = "0.28", features = ["build"] }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,188 @@
+# Makefile for cooklang-import
+# Supports building for iOS, Android, and native platforms
+
+.PHONY: all build test lint clean ios android bindings help install-deps
+
+# Default target
+all: build
+
+# Build the library (native)
+build:
+	cargo build --release
+
+# Build with UniFFI feature
+build-uniffi:
+	cargo build --release --features uniffi
+
+# Run tests
+test:
+	cargo test
+
+# Run tests with UniFFI feature
+test-uniffi:
+	cargo test --features uniffi
+
+# Run lints
+lint:
+	cargo fmt --check
+	cargo clippy -- -D warnings
+
+# Format code
+fmt:
+	cargo fmt
+
+# Clean build artifacts
+clean:
+	cargo clean
+	rm -rf target/ios target/android
+
+# Clean only mobile build artifacts
+clean-mobile:
+	rm -rf target/ios target/android
+
+# === iOS Builds ===
+
+# Build for iOS (requires macOS)
+ios:
+	@chmod +x scripts/build-ios.sh
+	@scripts/build-ios.sh
+
+# Build iOS release artifacts
+ios-release: ios
+	@echo "iOS release artifacts ready in target/ios/"
+
+# === Android Builds ===
+
+# Build for Android
+android:
+	@chmod +x scripts/build-android.sh
+	@scripts/build-android.sh
+
+# Build Android release artifacts
+android-release: android
+	@echo "Android release artifacts ready in target/android/"
+
+# === All Mobile Platforms ===
+
+# Build for all mobile platforms
+mobile: ios android
+	@echo "All mobile builds complete!"
+
+# === Bindings Generation ===
+
+# Generate Swift bindings only (without full iOS build)
+bindings-swift:
+	@mkdir -p target/bindings/swift
+	cargo build --release --features uniffi
+	uniffi-bindgen generate \
+		--library target/release/libcooklang_import.dylib \
+		--language swift \
+		--out-dir target/bindings/swift || \
+	uniffi-bindgen generate \
+		--library target/release/libcooklang_import.so \
+		--language swift \
+		--out-dir target/bindings/swift
+
+# Generate Kotlin bindings only (without full Android build)
+bindings-kotlin:
+	@mkdir -p target/bindings/kotlin
+	cargo build --release --features uniffi
+	uniffi-bindgen generate \
+		--library target/release/libcooklang_import.so \
+		--language kotlin \
+		--out-dir target/bindings/kotlin || \
+	uniffi-bindgen generate \
+		--library target/release/libcooklang_import.dylib \
+		--language kotlin \
+		--out-dir target/bindings/kotlin
+
+# Generate Python bindings
+bindings-python:
+	@mkdir -p target/bindings/python
+	cargo build --release --features uniffi
+	uniffi-bindgen generate \
+		--library target/release/libcooklang_import.so \
+		--language python \
+		--out-dir target/bindings/python || \
+	uniffi-bindgen generate \
+		--library target/release/libcooklang_import.dylib \
+		--language python \
+		--out-dir target/bindings/python
+
+# Generate Ruby bindings
+bindings-ruby:
+	@mkdir -p target/bindings/ruby
+	cargo build --release --features uniffi
+	uniffi-bindgen generate \
+		--library target/release/libcooklang_import.so \
+		--language ruby \
+		--out-dir target/bindings/ruby || \
+	uniffi-bindgen generate \
+		--library target/release/libcooklang_import.dylib \
+		--language ruby \
+		--out-dir target/bindings/ruby
+
+# Generate all bindings
+bindings: bindings-swift bindings-kotlin bindings-python bindings-ruby
+	@echo "All bindings generated in target/bindings/"
+
+# === Dependencies ===
+
+# Install development dependencies
+install-deps:
+	rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios || true
+	rustup target add aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android || true
+	cargo install uniffi-bindgen-cli --version 0.28 || true
+	cargo install cargo-ndk || true
+
+# === Release ===
+
+# Create a release build with all artifacts
+release: build-uniffi
+	@echo "Release build complete!"
+	@echo "Library: target/release/libcooklang_import.*"
+
+# === Documentation ===
+
+# Generate documentation
+docs:
+	cargo doc --no-deps --features uniffi
+	@echo "Documentation generated at target/doc/cooklang_import/"
+
+# === Help ===
+
+help:
+	@echo "cooklang-import build system"
+	@echo ""
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Native targets:"
+	@echo "  build         - Build native library (release)"
+	@echo "  build-uniffi  - Build with UniFFI feature enabled"
+	@echo "  test          - Run tests"
+	@echo "  test-uniffi   - Run tests with UniFFI feature"
+	@echo "  lint          - Run lints (fmt check + clippy)"
+	@echo "  fmt           - Format code"
+	@echo "  docs          - Generate documentation"
+	@echo "  clean         - Clean all build artifacts"
+	@echo ""
+	@echo "Mobile targets:"
+	@echo "  ios           - Build iOS XCFramework + Swift bindings"
+	@echo "  android       - Build Android AAR + Kotlin bindings"
+	@echo "  mobile        - Build for both iOS and Android"
+	@echo "  clean-mobile  - Clean only mobile artifacts"
+	@echo ""
+	@echo "Bindings targets:"
+	@echo "  bindings-swift   - Generate Swift bindings only"
+	@echo "  bindings-kotlin  - Generate Kotlin bindings only"
+	@echo "  bindings-python  - Generate Python bindings"
+	@echo "  bindings-ruby    - Generate Ruby bindings"
+	@echo "  bindings         - Generate all bindings"
+	@echo ""
+	@echo "Setup:"
+	@echo "  install-deps  - Install required tools and targets"
+	@echo ""
+	@echo "Release:"
+	@echo "  release       - Create release build"
+	@echo "  ios-release   - Create iOS release artifacts"
+	@echo "  android-release - Create Android release artifacts"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // UniFFI scaffolding is generated via proc-macros in uniffi_bindings.rs
+    // using uniffi::setup_scaffolding!() macro - no UDL file needed
+
+    // Ensure we rebuild when these files change
+    println!("cargo:rerun-if-changed=src/uniffi_bindings.rs");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -1,0 +1,366 @@
+#!/bin/bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Building cooklang-import for Android...${NC}"
+
+# Configuration
+PACKAGE_NAME="cooklang_import"
+LIB_NAME="libcooklang_import.so"
+OUTPUT_DIR="target/android"
+KOTLIN_OUTPUT_DIR="${OUTPUT_DIR}/kotlin"
+JNI_LIBS_DIR="${OUTPUT_DIR}/jniLibs"
+
+# Android targets and their ABI mappings
+declare -A ANDROID_TARGETS=(
+    ["aarch64-linux-android"]="arm64-v8a"
+    ["armv7-linux-androideabi"]="armeabi-v7a"
+    ["x86_64-linux-android"]="x86_64"
+    ["i686-linux-android"]="x86"
+)
+
+# Minimum API level
+MIN_API_LEVEL="${ANDROID_MIN_API_LEVEL:-21}"
+
+# Check for required tools
+check_requirements() {
+    echo -e "${YELLOW}Checking requirements...${NC}"
+
+    if ! command -v rustup &> /dev/null; then
+        echo -e "${RED}Error: rustup is not installed${NC}"
+        exit 1
+    fi
+
+    if ! command -v cargo &> /dev/null; then
+        echo -e "${RED}Error: cargo is not installed${NC}"
+        exit 1
+    fi
+
+    # Check for NDK
+    if [[ -z "${ANDROID_NDK_HOME:-}" ]] && [[ -z "${NDK_HOME:-}" ]]; then
+        # Try to find NDK in common locations
+        local ndk_locations=(
+            "$HOME/Android/Sdk/ndk"
+            "$HOME/Library/Android/sdk/ndk"
+            "/usr/local/android-sdk/ndk"
+        )
+
+        for loc in "${ndk_locations[@]}"; do
+            if [[ -d "$loc" ]]; then
+                # Get the latest NDK version
+                local latest_ndk
+                latest_ndk=$(ls -1 "$loc" 2>/dev/null | sort -V | tail -n1)
+                if [[ -n "$latest_ndk" ]]; then
+                    export ANDROID_NDK_HOME="$loc/$latest_ndk"
+                    echo -e "${YELLOW}Found NDK at: ${ANDROID_NDK_HOME}${NC}"
+                    break
+                fi
+            fi
+        done
+
+        if [[ -z "${ANDROID_NDK_HOME:-}" ]]; then
+            echo -e "${RED}Error: Android NDK not found${NC}"
+            echo "Please set ANDROID_NDK_HOME or NDK_HOME environment variable"
+            echo "Or install the NDK via Android Studio"
+            exit 1
+        fi
+    fi
+
+    NDK_HOME="${ANDROID_NDK_HOME:-$NDK_HOME}"
+    export NDK_HOME
+
+    # Check if uniffi-bindgen is installed
+    if ! cargo install --list | grep -q "uniffi-bindgen-cli"; then
+        echo -e "${YELLOW}Installing uniffi-bindgen-cli...${NC}"
+        cargo install uniffi-bindgen-cli --version 0.28
+    fi
+
+    # Check for cargo-ndk
+    if ! command -v cargo-ndk &> /dev/null; then
+        echo -e "${YELLOW}Installing cargo-ndk...${NC}"
+        cargo install cargo-ndk
+    fi
+
+    echo -e "${GREEN}All requirements met!${NC}"
+}
+
+# Install Android targets if needed
+install_targets() {
+    echo -e "${YELLOW}Installing Android targets...${NC}"
+    for target in "${!ANDROID_TARGETS[@]}"; do
+        if ! rustup target list --installed | grep -q "$target"; then
+            echo "Installing target: $target"
+            rustup target add "$target"
+        fi
+    done
+    echo -e "${GREEN}All targets installed!${NC}"
+}
+
+# Build for all Android targets
+build_targets() {
+    echo -e "${YELLOW}Building for Android targets...${NC}"
+
+    for target in "${!ANDROID_TARGETS[@]}"; do
+        local abi="${ANDROID_TARGETS[$target]}"
+        echo "Building for $target ($abi)..."
+
+        cargo ndk \
+            --target "$target" \
+            --platform "$MIN_API_LEVEL" \
+            build --release --features uniffi
+    done
+
+    echo -e "${GREEN}All targets built!${NC}"
+}
+
+# Generate Kotlin bindings
+generate_kotlin_bindings() {
+    echo -e "${YELLOW}Generating Kotlin bindings...${NC}"
+
+    mkdir -p "$KOTLIN_OUTPUT_DIR"
+
+    # Use one of the built libraries to generate bindings
+    local first_target
+    first_target=$(echo "${!ANDROID_TARGETS[@]}" | tr ' ' '\n' | head -n1)
+    local lib_path="target/${first_target}/release/${LIB_NAME}"
+
+    if [[ -f "$lib_path" ]]; then
+        cargo run --features uniffi --bin uniffi-bindgen generate \
+            --library "$lib_path" \
+            --language kotlin \
+            --out-dir "$KOTLIN_OUTPUT_DIR" 2>/dev/null || \
+        uniffi-bindgen generate \
+            --library "$lib_path" \
+            --language kotlin \
+            --out-dir "$KOTLIN_OUTPUT_DIR"
+    else
+        echo -e "${RED}Error: Library not found at $lib_path${NC}"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Kotlin bindings generated at ${KOTLIN_OUTPUT_DIR}${NC}"
+}
+
+# Organize libraries into jniLibs structure
+organize_jni_libs() {
+    echo -e "${YELLOW}Organizing JNI libraries...${NC}"
+
+    for target in "${!ANDROID_TARGETS[@]}"; do
+        local abi="${ANDROID_TARGETS[$target]}"
+        local src_lib="target/${target}/release/${LIB_NAME}"
+        local dst_dir="${JNI_LIBS_DIR}/${abi}"
+
+        if [[ -f "$src_lib" ]]; then
+            mkdir -p "$dst_dir"
+            cp "$src_lib" "$dst_dir/"
+            echo "Copied $target -> $abi"
+        else
+            echo -e "${YELLOW}Warning: Library not found for $target${NC}"
+        fi
+    done
+
+    echo -e "${GREEN}JNI libraries organized at ${JNI_LIBS_DIR}${NC}"
+}
+
+# Create Android library module structure
+create_android_library() {
+    echo -e "${YELLOW}Creating Android library module structure...${NC}"
+
+    local lib_dir="${OUTPUT_DIR}/cooklang-import-android"
+    mkdir -p "${lib_dir}/src/main/kotlin"
+    mkdir -p "${lib_dir}/src/main/jniLibs"
+
+    # Copy JNI libs
+    cp -R "${JNI_LIBS_DIR}"/* "${lib_dir}/src/main/jniLibs/"
+
+    # Copy Kotlin bindings
+    cp "${KOTLIN_OUTPUT_DIR}"/*.kt "${lib_dir}/src/main/kotlin/"
+
+    # Create build.gradle.kts
+    cat > "${lib_dir}/build.gradle.kts" << 'EOF'
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.cooklang.import"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 21
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
+    sourceSets {
+        getByName("main") {
+            jniLibs.srcDirs("src/main/jniLibs")
+        }
+    }
+}
+
+dependencies {
+    implementation("net.java.dev.jna:jna:5.14.0@aar")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}
+EOF
+
+    # Create proguard rules
+    cat > "${lib_dir}/proguard-rules.pro" << 'EOF'
+# Keep UniFFI generated code
+-keep class uniffi.** { *; }
+-keep class com.cooklang.** { *; }
+
+# Keep JNA classes
+-keep class com.sun.jna.** { *; }
+-keepclassmembers class * extends com.sun.jna.** { public *; }
+EOF
+
+    # Create consumer proguard rules
+    cat > "${lib_dir}/consumer-rules.pro" << 'EOF'
+# Consumer proguard rules for cooklang-import
+-keep class uniffi.** { *; }
+-keep class com.cooklang.** { *; }
+EOF
+
+    # Create AndroidManifest.xml
+    mkdir -p "${lib_dir}/src/main"
+    cat > "${lib_dir}/src/main/AndroidManifest.xml" << 'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>
+EOF
+
+    echo -e "${GREEN}Android library module created at ${lib_dir}${NC}"
+}
+
+# Create AAR package info
+create_package_info() {
+    echo -e "${YELLOW}Creating package info...${NC}"
+
+    cat > "${OUTPUT_DIR}/README.md" << EOF
+# CooklangImport Android Library
+
+This directory contains the Android bindings for cooklang-import.
+
+## Contents
+
+- \`cooklang-import-android/\` - Android library module ready to import
+- \`jniLibs/\` - Native libraries for each architecture
+- \`kotlin/\` - Generated Kotlin bindings
+
+## Supported Architectures
+
+- arm64-v8a (64-bit ARM)
+- armeabi-v7a (32-bit ARM)
+- x86_64 (64-bit x86)
+- x86 (32-bit x86)
+
+## Integration
+
+### Option 1: As a module
+
+1. Copy \`cooklang-import-android\` to your project
+2. Add to \`settings.gradle.kts\`:
+   \`\`\`kotlin
+   include(":cooklang-import-android")
+   \`\`\`
+3. Add dependency in your app's \`build.gradle.kts\`:
+   \`\`\`kotlin
+   implementation(project(":cooklang-import-android"))
+   \`\`\`
+
+### Option 2: Manual integration
+
+1. Copy \`jniLibs/\` to \`app/src/main/jniLibs/\`
+2. Copy Kotlin files from \`kotlin/\` to your source
+3. Add JNA dependency:
+   \`\`\`kotlin
+   implementation("net.java.dev.jna:jna:5.14.0@aar")
+   \`\`\`
+
+## Usage
+
+\`\`\`kotlin
+import uniffi.cooklang_import.*
+
+// Simple import
+val cooklang = simpleImport("https://example.com/recipe")
+
+// With configuration
+val config = FfiImportConfig(
+    provider = FfiLlmProvider.ANTHROPIC,
+    apiKey = "your-api-key",
+    model = null,
+    timeoutSeconds = 30u,
+    extractOnly = false
+)
+val result = importFromUrl("https://example.com/recipe", config)
+\`\`\`
+
+## Requirements
+
+- Minimum SDK: 21 (Android 5.0)
+- JNA library for FFI
+EOF
+
+    echo -e "${GREEN}Package info created${NC}"
+}
+
+# Main execution
+main() {
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}  cooklang-import Android Build Script  ${NC}"
+    echo -e "${GREEN}========================================${NC}"
+
+    check_requirements
+    install_targets
+    build_targets
+    generate_kotlin_bindings
+    organize_jni_libs
+    create_android_library
+    create_package_info
+
+    echo ""
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}  Build Complete!                       ${NC}"
+    echo -e "${GREEN}========================================${NC}"
+    echo ""
+    echo "Output files:"
+    echo "  - JNI Libraries: ${JNI_LIBS_DIR}"
+    echo "  - Kotlin bindings: ${KOTLIN_OUTPUT_DIR}"
+    echo "  - Android module: ${OUTPUT_DIR}/cooklang-import-android"
+    echo ""
+    echo "See ${OUTPUT_DIR}/README.md for integration instructions."
+}
+
+main "$@"

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Building cooklang-import for iOS...${NC}"
+
+# Configuration
+PACKAGE_NAME="cooklang_import"
+LIB_NAME="libcooklang_import.a"
+FRAMEWORK_NAME="CooklangImportFFI"
+OUTPUT_DIR="target/ios"
+SWIFT_OUTPUT_DIR="${OUTPUT_DIR}/swift"
+XCFRAMEWORK_OUTPUT="${OUTPUT_DIR}/${FRAMEWORK_NAME}.xcframework"
+
+# iOS targets
+IOS_TARGETS=(
+    "aarch64-apple-ios"           # iOS devices (arm64)
+    "aarch64-apple-ios-sim"       # iOS Simulator (arm64, Apple Silicon Macs)
+    "x86_64-apple-ios"            # iOS Simulator (x86_64, Intel Macs)
+)
+
+# Check for required tools
+check_requirements() {
+    echo -e "${YELLOW}Checking requirements...${NC}"
+
+    if ! command -v rustup &> /dev/null; then
+        echo -e "${RED}Error: rustup is not installed${NC}"
+        exit 1
+    fi
+
+    if ! command -v cargo &> /dev/null; then
+        echo -e "${RED}Error: cargo is not installed${NC}"
+        exit 1
+    fi
+
+    if ! command -v xcrun &> /dev/null; then
+        echo -e "${RED}Error: Xcode command line tools are not installed${NC}"
+        exit 1
+    fi
+
+    # Check if uniffi-bindgen is installed
+    if ! cargo install --list | grep -q "uniffi-bindgen-cli"; then
+        echo -e "${YELLOW}Installing uniffi-bindgen-cli...${NC}"
+        cargo install uniffi-bindgen-cli --version 0.28
+    fi
+
+    echo -e "${GREEN}All requirements met!${NC}"
+}
+
+# Install iOS targets if needed
+install_targets() {
+    echo -e "${YELLOW}Installing iOS targets...${NC}"
+    for target in "${IOS_TARGETS[@]}"; do
+        if ! rustup target list --installed | grep -q "$target"; then
+            echo "Installing target: $target"
+            rustup target add "$target"
+        fi
+    done
+    echo -e "${GREEN}All targets installed!${NC}"
+}
+
+# Build for all iOS targets
+build_targets() {
+    echo -e "${YELLOW}Building for iOS targets...${NC}"
+
+    for target in "${IOS_TARGETS[@]}"; do
+        echo "Building for $target..."
+        cargo build --release --target "$target" --features uniffi
+    done
+
+    echo -e "${GREEN}All targets built!${NC}"
+}
+
+# Generate Swift bindings
+generate_swift_bindings() {
+    echo -e "${YELLOW}Generating Swift bindings...${NC}"
+
+    mkdir -p "$SWIFT_OUTPUT_DIR"
+
+    # Use the first available library to generate bindings
+    local lib_path="target/${IOS_TARGETS[0]}/release/${LIB_NAME}"
+
+    if [[ -f "$lib_path" ]]; then
+        cargo run --features uniffi --bin uniffi-bindgen generate \
+            --library "$lib_path" \
+            --language swift \
+            --out-dir "$SWIFT_OUTPUT_DIR" 2>/dev/null || \
+        uniffi-bindgen generate \
+            --library "$lib_path" \
+            --language swift \
+            --out-dir "$SWIFT_OUTPUT_DIR"
+    else
+        echo -e "${RED}Error: Library not found at $lib_path${NC}"
+        exit 1
+    fi
+
+    echo -e "${GREEN}Swift bindings generated at ${SWIFT_OUTPUT_DIR}${NC}"
+}
+
+# Create XCFramework
+create_xcframework() {
+    echo -e "${YELLOW}Creating XCFramework...${NC}"
+
+    # Clean previous xcframework
+    rm -rf "$XCFRAMEWORK_OUTPUT"
+
+    # Create temporary directories for each platform
+    local ios_device_dir="${OUTPUT_DIR}/ios-device"
+    local ios_sim_dir="${OUTPUT_DIR}/ios-simulator"
+
+    mkdir -p "$ios_device_dir" "$ios_sim_dir"
+
+    # Copy device library
+    cp "target/aarch64-apple-ios/release/${LIB_NAME}" "$ios_device_dir/"
+
+    # Create fat library for simulator (arm64 + x86_64)
+    echo "Creating fat library for iOS Simulator..."
+    lipo -create \
+        "target/aarch64-apple-ios-sim/release/${LIB_NAME}" \
+        "target/x86_64-apple-ios/release/${LIB_NAME}" \
+        -output "$ios_sim_dir/${LIB_NAME}"
+
+    # Create module.modulemap
+    local modulemap_content="module ${FRAMEWORK_NAME} {
+    header \"${PACKAGE_NAME}FFI.h\"
+    export *
+}"
+
+    # Create headers and modulemap for device
+    mkdir -p "$ios_device_dir/Headers"
+    cp "${SWIFT_OUTPUT_DIR}/${PACKAGE_NAME}FFI.h" "$ios_device_dir/Headers/"
+    mkdir -p "$ios_device_dir/Modules"
+    echo "$modulemap_content" > "$ios_device_dir/Modules/module.modulemap"
+
+    # Create headers and modulemap for simulator
+    mkdir -p "$ios_sim_dir/Headers"
+    cp "${SWIFT_OUTPUT_DIR}/${PACKAGE_NAME}FFI.h" "$ios_sim_dir/Headers/"
+    mkdir -p "$ios_sim_dir/Modules"
+    echo "$modulemap_content" > "$ios_sim_dir/Modules/module.modulemap"
+
+    # Create XCFramework
+    xcodebuild -create-xcframework \
+        -library "$ios_device_dir/${LIB_NAME}" \
+        -headers "$ios_device_dir/Headers" \
+        -library "$ios_sim_dir/${LIB_NAME}" \
+        -headers "$ios_sim_dir/Headers" \
+        -output "$XCFRAMEWORK_OUTPUT"
+
+    # Copy Swift file alongside XCFramework
+    cp "${SWIFT_OUTPUT_DIR}/${PACKAGE_NAME}.swift" "${OUTPUT_DIR}/"
+
+    # Cleanup temp directories
+    rm -rf "$ios_device_dir" "$ios_sim_dir"
+
+    echo -e "${GREEN}XCFramework created at ${XCFRAMEWORK_OUTPUT}${NC}"
+}
+
+# Create Swift Package
+create_swift_package() {
+    echo -e "${YELLOW}Creating Swift Package structure...${NC}"
+
+    local swift_pkg_dir="${OUTPUT_DIR}/CooklangImport"
+    mkdir -p "${swift_pkg_dir}/Sources/CooklangImport"
+
+    # Copy Swift bindings
+    cp "${SWIFT_OUTPUT_DIR}/${PACKAGE_NAME}.swift" "${swift_pkg_dir}/Sources/CooklangImport/"
+
+    # Create Package.swift
+    cat > "${swift_pkg_dir}/Package.swift" << 'EOF'
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "CooklangImport",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15)
+    ],
+    products: [
+        .library(
+            name: "CooklangImport",
+            targets: ["CooklangImport", "CooklangImportFFI"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CooklangImport",
+            dependencies: ["CooklangImportFFI"]
+        ),
+        .binaryTarget(
+            name: "CooklangImportFFI",
+            path: "CooklangImportFFI.xcframework"
+        ),
+    ]
+)
+EOF
+
+    # Copy XCFramework into the package
+    cp -R "$XCFRAMEWORK_OUTPUT" "${swift_pkg_dir}/"
+
+    echo -e "${GREEN}Swift Package created at ${swift_pkg_dir}${NC}"
+}
+
+# Main execution
+main() {
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}  cooklang-import iOS Build Script      ${NC}"
+    echo -e "${GREEN}========================================${NC}"
+
+    check_requirements
+    install_targets
+    build_targets
+    generate_swift_bindings
+    create_xcframework
+    create_swift_package
+
+    echo ""
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}  Build Complete!                       ${NC}"
+    echo -e "${GREEN}========================================${NC}"
+    echo ""
+    echo "Output files:"
+    echo "  - XCFramework: ${XCFRAMEWORK_OUTPUT}"
+    echo "  - Swift bindings: ${OUTPUT_DIR}/${PACKAGE_NAME}.swift"
+    echo "  - Swift Package: ${OUTPUT_DIR}/CooklangImport/"
+    echo ""
+    echo "To use in your iOS project:"
+    echo "  1. Add the XCFramework to your Xcode project"
+    echo "  2. Add the Swift bindings file to your project"
+    echo ""
+    echo "Or use the Swift Package:"
+    echo "  1. Copy ${OUTPUT_DIR}/CooklangImport to your project"
+    echo "  2. Add it as a local Swift Package dependency"
+}
+
+main "$@"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,13 @@ pub mod model;
 pub mod ocr;
 pub mod providers;
 
+#[cfg(feature = "uniffi")]
+pub mod uniffi_bindings;
+
+// Re-export UniFFI types when feature is enabled
+#[cfg(feature = "uniffi")]
+pub use uniffi_bindings::*;
+
 // Public API exports
 // Builder API (primary interface)
 pub use builder::{ImportResult, LlmProvider, RecipeImporter};

--- a/src/uniffi_bindings.rs
+++ b/src/uniffi_bindings.rs
@@ -1,0 +1,476 @@
+//! UniFFI bindings for cooklang-import
+//!
+//! This module provides FFI-compatible types and functions for use with iOS and Android.
+//! It wraps the async Rust API with synchronous functions that manage their own tokio runtime.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::time::Duration;
+
+use crate::{ImportError, Recipe};
+
+// Re-export UniFFI macro
+#[cfg(feature = "uniffi")]
+uniffi::setup_scaffolding!();
+
+/// FFI-compatible recipe structure
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct FfiRecipe {
+    /// Recipe name/title
+    pub name: String,
+    /// Recipe description (empty string if none)
+    pub description: String,
+    /// List of image URLs
+    pub images: Vec<String>,
+    /// Recipe content in markdown format
+    pub content: String,
+    /// Metadata as key-value pairs
+    pub metadata: Vec<FfiKeyValue>,
+}
+
+/// Key-value pair for metadata (since HashMap isn't directly supported in UniFFI)
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct FfiKeyValue {
+    pub key: String,
+    pub value: String,
+}
+
+impl From<Recipe> for FfiRecipe {
+    fn from(recipe: Recipe) -> Self {
+        FfiRecipe {
+            name: recipe.name,
+            description: recipe.description.unwrap_or_default(),
+            images: recipe.image,
+            content: recipe.content,
+            metadata: recipe
+                .metadata
+                .into_iter()
+                .map(|(key, value)| FfiKeyValue { key, value })
+                .collect(),
+        }
+    }
+}
+
+impl From<FfiRecipe> for Recipe {
+    fn from(ffi: FfiRecipe) -> Self {
+        Recipe {
+            name: ffi.name,
+            description: if ffi.description.is_empty() {
+                None
+            } else {
+                Some(ffi.description)
+            },
+            image: ffi.images,
+            content: ffi.content,
+            metadata: ffi
+                .metadata
+                .into_iter()
+                .map(|kv| (kv.key, kv.value))
+                .collect(),
+        }
+    }
+}
+
+/// FFI-compatible LLM provider enum
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum FfiLlmProvider {
+    OpenAI,
+    Anthropic,
+    Google,
+    AzureOpenAI,
+    Ollama,
+}
+
+impl From<FfiLlmProvider> for crate::LlmProvider {
+    fn from(provider: FfiLlmProvider) -> Self {
+        match provider {
+            FfiLlmProvider::OpenAI => crate::LlmProvider::OpenAI,
+            FfiLlmProvider::Anthropic => crate::LlmProvider::Anthropic,
+            FfiLlmProvider::Google => crate::LlmProvider::Google,
+            FfiLlmProvider::AzureOpenAI => crate::LlmProvider::AzureOpenAI,
+            FfiLlmProvider::Ollama => crate::LlmProvider::Ollama,
+        }
+    }
+}
+
+/// FFI-compatible import result
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Enum))]
+pub enum FfiImportResult {
+    /// Recipe converted to Cooklang format
+    Cooklang { content: String },
+    /// Recipe extracted but not converted
+    Recipe { recipe: FfiRecipe },
+}
+
+/// FFI-compatible error type
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Error))]
+pub enum FfiImportError {
+    /// Failed to fetch recipe from URL
+    FetchError { message: String },
+    /// Failed to parse recipe from webpage
+    ParseError { message: String },
+    /// No extractor could successfully parse the recipe
+    NoExtractorMatched { message: String },
+    /// Failed to convert recipe to Cooklang format
+    ConversionError { message: String },
+    /// Invalid input provided
+    InvalidInput { message: String },
+    /// Builder configuration error
+    BuilderError { message: String },
+    /// Configuration error
+    ConfigError { message: String },
+    /// Runtime error (tokio)
+    RuntimeError { message: String },
+}
+
+impl fmt::Display for FfiImportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FfiImportError::FetchError { message } => write!(f, "Fetch error: {}", message),
+            FfiImportError::ParseError { message } => write!(f, "Parse error: {}", message),
+            FfiImportError::NoExtractorMatched { message } => {
+                write!(f, "No extractor matched: {}", message)
+            }
+            FfiImportError::ConversionError { message } => {
+                write!(f, "Conversion error: {}", message)
+            }
+            FfiImportError::InvalidInput { message } => write!(f, "Invalid input: {}", message),
+            FfiImportError::BuilderError { message } => write!(f, "Builder error: {}", message),
+            FfiImportError::ConfigError { message } => write!(f, "Config error: {}", message),
+            FfiImportError::RuntimeError { message } => write!(f, "Runtime error: {}", message),
+        }
+    }
+}
+
+impl std::error::Error for FfiImportError {}
+
+impl From<ImportError> for FfiImportError {
+    fn from(err: ImportError) -> Self {
+        match err {
+            ImportError::FetchError(e) => FfiImportError::FetchError {
+                message: e.to_string(),
+            },
+            ImportError::ParseError(msg) => FfiImportError::ParseError { message: msg },
+            ImportError::NoExtractorMatched => FfiImportError::NoExtractorMatched {
+                message: "No extractor could parse the recipe from this webpage".to_string(),
+            },
+            ImportError::ConversionError(msg) => FfiImportError::ConversionError { message: msg },
+            ImportError::InvalidMarkdown(msg) => FfiImportError::InvalidInput { message: msg },
+            ImportError::BuilderError(msg) => FfiImportError::BuilderError { message: msg },
+            ImportError::HeaderError(e) => FfiImportError::FetchError {
+                message: e.to_string(),
+            },
+            ImportError::EnvError(e) => FfiImportError::ConfigError {
+                message: e.to_string(),
+            },
+            ImportError::ConfigError(e) => FfiImportError::ConfigError {
+                message: e.to_string(),
+            },
+        }
+    }
+}
+
+/// Configuration for importing recipes
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "uniffi", derive(uniffi::Record))]
+pub struct FfiImportConfig {
+    /// Optional LLM provider (uses default if not specified)
+    pub provider: Option<FfiLlmProvider>,
+    /// Optional API key (uses environment variable if not specified)
+    pub api_key: Option<String>,
+    /// Optional model name (uses provider default if not specified)
+    pub model: Option<String>,
+    /// Optional timeout in seconds (uses default if not specified)
+    pub timeout_seconds: Option<u64>,
+    /// If true, only extract recipe without converting to Cooklang
+    pub extract_only: bool,
+}
+
+/// Create a new tokio runtime for FFI calls
+fn create_runtime() -> Result<tokio::runtime::Runtime, FfiImportError> {
+    tokio::runtime::Runtime::new().map_err(|e| FfiImportError::RuntimeError {
+        message: format!("Failed to create async runtime: {}", e),
+    })
+}
+
+/// Import a recipe from a URL
+///
+/// # Arguments
+/// * `url` - The URL of the recipe webpage
+/// * `config` - Optional configuration for the import
+///
+/// # Returns
+/// An `FfiImportResult` containing either Cooklang text or a Recipe struct
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn import_from_url(
+    url: String,
+    config: Option<FfiImportConfig>,
+) -> Result<FfiImportResult, FfiImportError> {
+    let rt = create_runtime()?;
+    rt.block_on(async { import_from_url_async(&url, config).await })
+}
+
+async fn import_from_url_async(
+    url: &str,
+    config: Option<FfiImportConfig>,
+) -> Result<FfiImportResult, FfiImportError> {
+    let config = config.unwrap_or_default();
+
+    let mut builder = crate::RecipeImporter::builder().url(url);
+
+    if let Some(provider) = config.provider {
+        builder = builder.provider(provider.into());
+    }
+
+    if let Some(api_key) = config.api_key {
+        builder = builder.api_key(api_key);
+    }
+
+    if let Some(model) = config.model {
+        builder = builder.model(model);
+    }
+
+    if let Some(timeout_secs) = config.timeout_seconds {
+        builder = builder.timeout(Duration::from_secs(timeout_secs));
+    }
+
+    if config.extract_only {
+        builder = builder.extract_only();
+    }
+
+    let result = builder.build().await?;
+
+    Ok(match result {
+        crate::ImportResult::Cooklang(content) => FfiImportResult::Cooklang { content },
+        crate::ImportResult::Recipe(recipe) => FfiImportResult::Recipe {
+            recipe: recipe.into(),
+        },
+    })
+}
+
+/// Convert plain text to Cooklang format
+///
+/// # Arguments
+/// * `text` - The recipe text in plain format
+/// * `config` - Optional configuration for the conversion
+///
+/// # Returns
+/// A string containing the recipe in Cooklang format
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn convert_text_to_cooklang(
+    text: String,
+    config: Option<FfiImportConfig>,
+) -> Result<String, FfiImportError> {
+    let rt = create_runtime()?;
+    rt.block_on(async { convert_text_async(&text, config).await })
+}
+
+async fn convert_text_async(
+    text: &str,
+    config: Option<FfiImportConfig>,
+) -> Result<String, FfiImportError> {
+    let config = config.unwrap_or_default();
+
+    let mut builder = crate::RecipeImporter::builder().text(text);
+
+    if let Some(provider) = config.provider {
+        builder = builder.provider(provider.into());
+    }
+
+    if let Some(api_key) = config.api_key {
+        builder = builder.api_key(api_key);
+    }
+
+    if let Some(model) = config.model {
+        builder = builder.model(model);
+    }
+
+    let result = builder.build().await?;
+
+    match result {
+        crate::ImportResult::Cooklang(content) => Ok(content),
+        crate::ImportResult::Recipe(_) => Err(FfiImportError::BuilderError {
+            message: "Unexpected recipe result when converting text".to_string(),
+        }),
+    }
+}
+
+/// Convert an image to Cooklang format using OCR
+///
+/// # Arguments
+/// * `image_path` - Path to the image file
+/// * `config` - Optional configuration for the conversion
+///
+/// # Returns
+/// A string containing the recipe in Cooklang format
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn convert_image_to_cooklang(
+    image_path: String,
+    config: Option<FfiImportConfig>,
+) -> Result<String, FfiImportError> {
+    let rt = create_runtime()?;
+    rt.block_on(async { convert_image_async(&image_path, config).await })
+}
+
+async fn convert_image_async(
+    image_path: &str,
+    config: Option<FfiImportConfig>,
+) -> Result<String, FfiImportError> {
+    let config = config.unwrap_or_default();
+
+    let mut builder = crate::RecipeImporter::builder().image(image_path);
+
+    if let Some(provider) = config.provider {
+        builder = builder.provider(provider.into());
+    }
+
+    if let Some(api_key) = config.api_key {
+        builder = builder.api_key(api_key);
+    }
+
+    if let Some(model) = config.model {
+        builder = builder.model(model);
+    }
+
+    let result = builder.build().await?;
+
+    match result {
+        crate::ImportResult::Cooklang(content) => Ok(content),
+        crate::ImportResult::Recipe(_) => Err(FfiImportError::BuilderError {
+            message: "Unexpected recipe result when converting image".to_string(),
+        }),
+    }
+}
+
+/// Extract a recipe from a URL without converting to Cooklang format
+///
+/// # Arguments
+/// * `url` - The URL of the recipe webpage
+/// * `timeout_seconds` - Optional timeout in seconds
+///
+/// # Returns
+/// An `FfiRecipe` struct containing the extracted recipe data
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn extract_recipe_from_url(
+    url: String,
+    timeout_seconds: Option<u64>,
+) -> Result<FfiRecipe, FfiImportError> {
+    let rt = create_runtime()?;
+    rt.block_on(async {
+        let timeout = timeout_seconds.map(Duration::from_secs);
+        let recipe = crate::fetch_recipe_with_timeout(&url, timeout).await?;
+        Ok(recipe.into())
+    })
+}
+
+/// Generate Cooklang frontmatter from metadata
+///
+/// # Arguments
+/// * `metadata` - List of key-value pairs
+///
+/// # Returns
+/// A string containing the frontmatter in Cooklang format
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn generate_frontmatter(metadata: Vec<FfiKeyValue>) -> String {
+    let map: HashMap<String, String> = metadata.into_iter().map(|kv| (kv.key, kv.value)).collect();
+    crate::generate_frontmatter(&map)
+}
+
+/// Simple import from URL with default settings
+///
+/// This is a convenience function that imports a recipe from a URL
+/// using default settings and returns the Cooklang-formatted result.
+///
+/// # Arguments
+/// * `url` - The URL of the recipe webpage
+///
+/// # Returns
+/// A string containing the recipe in Cooklang format
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn simple_import(url: String) -> Result<String, FfiImportError> {
+    import_from_url(url, None).map(|result| match result {
+        FfiImportResult::Cooklang { content } => content,
+        FfiImportResult::Recipe { recipe } => recipe.content,
+    })
+}
+
+/// Get the library version
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn get_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Check if a provider is available (has required environment variables)
+#[cfg_attr(feature = "uniffi", uniffi::export)]
+pub fn is_provider_available(provider: FfiLlmProvider) -> bool {
+    match provider {
+        FfiLlmProvider::OpenAI => std::env::var("OPENAI_API_KEY").is_ok(),
+        FfiLlmProvider::Anthropic => std::env::var("ANTHROPIC_API_KEY").is_ok(),
+        FfiLlmProvider::Google => std::env::var("GOOGLE_API_KEY").is_ok(),
+        FfiLlmProvider::AzureOpenAI => {
+            std::env::var("AZURE_OPENAI_API_KEY").is_ok()
+                && std::env::var("AZURE_OPENAI_ENDPOINT").is_ok()
+        }
+        FfiLlmProvider::Ollama => {
+            // Ollama doesn't require API key, check if base URL is set or use default
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ffi_recipe_conversion() {
+        let recipe = Recipe {
+            name: "Test Recipe".to_string(),
+            description: Some("A test".to_string()),
+            image: vec!["http://example.com/image.jpg".to_string()],
+            content: "# Test\nContent here".to_string(),
+            metadata: [("author".to_string(), "Chef".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let ffi_recipe: FfiRecipe = recipe.clone().into();
+        assert_eq!(ffi_recipe.name, "Test Recipe");
+        assert_eq!(ffi_recipe.description, "A test");
+        assert_eq!(ffi_recipe.images.len(), 1);
+        assert_eq!(ffi_recipe.metadata.len(), 1);
+
+        let back: Recipe = ffi_recipe.into();
+        assert_eq!(back.name, recipe.name);
+        assert_eq!(back.description, recipe.description);
+    }
+
+    #[test]
+    fn test_get_version() {
+        let version = get_version();
+        assert!(!version.is_empty());
+    }
+
+    #[test]
+    fn test_generate_frontmatter_ffi() {
+        let metadata = vec![
+            FfiKeyValue {
+                key: "author".to_string(),
+                value: "Chef".to_string(),
+            },
+            FfiKeyValue {
+                key: "servings".to_string(),
+                value: "4".to_string(),
+            },
+        ];
+
+        let frontmatter = generate_frontmatter(metadata);
+        assert!(frontmatter.contains("author: Chef"));
+        assert!(frontmatter.contains("servings: 4"));
+    }
+}


### PR DESCRIPTION
Add FFI bindings using UniFFI derives to enable using this library from iOS (Swift) and Android (Kotlin) applications.

Changes:
- Add uniffi feature flag and dependencies to Cargo.toml
- Create uniffi_bindings.rs with FFI-compatible wrapper types
- Add build scripts for iOS (XCFramework) and Android (JNI libs)
- Add Makefile for build orchestration
- Add GitHub Actions release workflow for mobile artifacts

The FFI API exposes:
- import_from_url: Import recipe from URL
- convert_text_to_cooklang: Convert plain text to Cooklang
- convert_image_to_cooklang: OCR image and convert to Cooklang
- extract_recipe_from_url: Extract recipe without conversion
- generate_frontmatter: Create Cooklang frontmatter
- simple_import: Convenience function for basic imports
- get_version: Get library version
- is_provider_available: Check if LLM provider is configured