### PR TITLE
fix: quote YAML metadata values containing special characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror 1.0.69",
  "tokio",
  "uniffi",
@@ -1659,6 +1660,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2175,12 @@ dependencies = [
  "uniffi_testing",
  "weedle2",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ whatlang = "0.16"
 # Only enable required tokio features - saves ~100KB
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "fs"] }
 uniffi = { version = "0.28", optional = true }
+serde_yaml = "0.9"
 
 [dev-dependencies]
 mockito = "1.5.0"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -364,7 +364,7 @@ impl RecipeImporterBuilder {
         if has_name || has_metadata {
             output.push_str("---\n");
             if has_name {
-                output.push_str(&format!("title: {}\n", components.name));
+                output.push_str(&format!("title: {}\n", crate::pipelines::yaml_escape(&components.name)));
             }
             if has_metadata {
                 output.push_str(&components.metadata);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -364,7 +364,10 @@ impl RecipeImporterBuilder {
         if has_name || has_metadata {
             output.push_str("---\n");
             if has_name {
-                output.push_str(&format!("title: {}\n", crate::pipelines::yaml_escape(&components.name)));
+                output.push_str(&format!(
+                    "title: {}\n",
+                    crate::pipelines::yaml_escape(&components.name)
+                ));
             }
             if has_metadata {
                 output.push_str(&components.metadata);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -364,10 +364,11 @@ impl RecipeImporterBuilder {
         if has_name || has_metadata {
             output.push_str("---\n");
             if has_name {
-                output.push_str(&format!(
-                    "title: {}\n",
-                    crate::pipelines::yaml_escape(&components.name)
-                ));
+                let title_yaml = crate::pipelines::metadata_to_yaml(&[(
+                    "title".to_string(),
+                    components.name.clone(),
+                )]);
+                output.push_str(&title_yaml);
             }
             if has_metadata {
                 output.push_str(&components.metadata);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,10 @@ pub async fn text_to_cooklang(components: &RecipeComponents) -> Result<String, I
             if has_name || has_metadata {
                 let mut frontmatter = String::from("---\n");
                 if has_name {
-                    frontmatter.push_str(&format!("title: {}\n", crate::pipelines::yaml_escape(&components.name)));
+                    frontmatter.push_str(&format!(
+                        "title: {}\n",
+                        crate::pipelines::yaml_escape(&components.name)
+                    ));
                 }
                 if has_metadata {
                     frontmatter.push_str(&components.metadata);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,10 +161,11 @@ pub async fn text_to_cooklang(components: &RecipeComponents) -> Result<String, I
             if has_name || has_metadata {
                 let mut frontmatter = String::from("---\n");
                 if has_name {
-                    frontmatter.push_str(&format!(
-                        "title: {}\n",
-                        crate::pipelines::yaml_escape(&components.name)
-                    ));
+                    let title_yaml = crate::pipelines::metadata_to_yaml(&[(
+                        "title".to_string(),
+                        components.name.clone(),
+                    )]);
+                    frontmatter.push_str(&title_yaml);
                 }
                 if has_metadata {
                     frontmatter.push_str(&components.metadata);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub async fn text_to_cooklang(components: &RecipeComponents) -> Result<String, I
             if has_name || has_metadata {
                 let mut frontmatter = String::from("---\n");
                 if has_name {
-                    frontmatter.push_str(&format!("title: {}\n", components.name));
+                    frontmatter.push_str(&format!("title: {}\n", crate::pipelines::yaml_escape(&components.name)));
                 }
                 if has_metadata {
                     frontmatter.push_str(&components.metadata);

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,4 @@
-use crate::pipelines::yaml_escape;
+use crate::pipelines::metadata_to_yaml;
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -17,24 +17,28 @@ impl Recipe {
     pub fn to_text_with_metadata(&self) -> String {
         let mut output = String::new();
 
-        // Build metadata including name
-        let mut metadata = self.metadata.clone();
+        // Build metadata entries including name
+        let mut entries: Vec<(String, String)> = Vec::new();
         if !self.name.is_empty() {
-            metadata.insert("title".to_string(), self.name.clone());
+            entries.push(("title".to_string(), self.name.clone()));
         }
         if let Some(desc) = &self.description {
-            metadata.insert("description".to_string(), desc.clone());
+            entries.push(("description".to_string(), desc.clone()));
         }
-        // Preserve image array as comma-separated string
         if !self.image.is_empty() {
-            metadata.insert("__image__".to_string(), self.image.join(", "));
+            entries.push(("__image__".to_string(), self.image.join(", ")));
+        }
+        for (key, value) in &self.metadata {
+            entries.push((key.clone(), value.clone()));
         }
 
         // YAML frontmatter
-        if !metadata.is_empty() {
+        let yaml = metadata_to_yaml(&entries);
+        if !yaml.is_empty() {
             output.push_str("---\n");
-            for (key, value) in &metadata {
-                output.push_str(&format!("{}: {}\n", key, yaml_escape(value)));
+            output.push_str(&yaml);
+            if !yaml.ends_with('\n') {
+                output.push('\n');
             }
             output.push_str("---\n\n");
         }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,3 +1,4 @@
+use crate::pipelines::yaml_escape;
 use serde::Serialize;
 use std::collections::HashMap;
 
@@ -33,7 +34,7 @@ impl Recipe {
         if !metadata.is_empty() {
             output.push_str("---\n");
             for (key, value) in &metadata {
-                output.push_str(&format!("{}: {}\n", key, value));
+                output.push_str(&format!("{}: {}\n", key, yaml_escape(value)));
             }
             output.push_str("---\n\n");
         }

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -19,33 +19,37 @@ pub fn sanitize_name(name: &str) -> String {
     name.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// Escape a YAML value by wrapping it in double quotes if it contains
-/// characters that are special in YAML (e.g. `:`, `#`, `[`, `]`, `{`, `}`).
+/// Serialize a YAML scalar value using serde_yaml.
 pub fn yaml_escape(value: &str) -> String {
-    if value.contains(':')
-        || value.contains('#')
-        || value.contains('[')
-        || value.contains(']')
-        || value.contains('{')
-        || value.contains('}')
-        || value.contains('"')
-        || value.contains('\'')
-        || value.contains('*')
-        || value.contains('&')
-        || value.contains('!')
-        || value.contains('|')
-        || value.contains('>')
-        || value.contains('%')
-        || value.contains('@')
-        || value.contains('`')
-        || value.starts_with(' ')
-        || value.ends_with(' ')
-    {
-        // Escape existing double quotes and backslashes, then wrap
-        let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
-        format!("\"{}\"", escaped)
+    let yaml = serde_yaml::to_string(&value).unwrap_or_else(|_| value.to_string());
+    yaml.trim_end().to_string()
+}
+
+/// Build a YAML metadata string from a Recipe's fields.
+/// Handles nested values (e.g. nutrition) by parsing pre-formatted YAML blocks.
+pub fn metadata_to_yaml(entries: &[(String, String)]) -> String {
+    use serde_yaml::Value;
+
+    let mut mapping = serde_yaml::Mapping::new();
+
+    for (key, value) in entries {
+        if value.starts_with('\n') {
+            // Pre-formatted nested YAML (e.g. nutrition) — parse as nested mapping
+            let yaml_str = format!("{}:{}", key, value);
+            if let Ok(parsed) = serde_yaml::from_str::<serde_yaml::Mapping>(&yaml_str) {
+                for (k, v) in parsed {
+                    mapping.insert(k, v);
+                }
+                continue;
+            }
+        }
+        mapping.insert(Value::String(key.clone()), Value::String(value.clone()));
+    }
+
+    if mapping.is_empty() {
+        String::new()
     } else {
-        value.to_string()
+        serde_yaml::to_string(&mapping).unwrap_or_default()
     }
 }
 
@@ -60,25 +64,52 @@ mod tests {
 
     #[test]
     fn test_yaml_escape_colon() {
-        assert_eq!(yaml_escape("test : sub"), "\"test : sub\"");
+        assert_eq!(yaml_escape("test : sub"), "'test : sub'");
     }
 
     #[test]
     fn test_yaml_escape_url() {
         assert_eq!(
             yaml_escape("http://example.com/recipe"),
-            "\"http://example.com/recipe\""
+            "http://example.com/recipe"
         );
     }
 
     #[test]
-    fn test_yaml_escape_with_quotes() {
-        assert_eq!(yaml_escape("say \"hello\""), "\"say \\\"hello\\\"\"");
+    fn test_yaml_escape_hash() {
+        assert_eq!(yaml_escape("value # comment"), "'value # comment'");
     }
 
     #[test]
-    fn test_yaml_escape_hash() {
-        assert_eq!(yaml_escape("value # comment"), "\"value # comment\"");
+    fn test_metadata_to_yaml_simple() {
+        let entries = vec![
+            ("source".to_string(), "http://example.com".to_string()),
+            ("servings".to_string(), "4".to_string()),
+        ];
+        let yaml = metadata_to_yaml(&entries);
+        assert!(yaml.contains("source: http://example.com"));
+        assert!(yaml.contains("servings: '4'"));
+    }
+
+    #[test]
+    fn test_metadata_to_yaml_with_colon() {
+        let entries = vec![("description".to_string(), "test : sub".to_string())];
+        let yaml = metadata_to_yaml(&entries);
+        assert!(yaml.contains("description: 'test : sub'"));
+    }
+
+    #[test]
+    fn test_metadata_to_yaml_nested() {
+        let entries = vec![(
+            "nutrition".to_string(),
+            "\n  calories: 330 calories\n  fat: 18 grams fat".to_string(),
+        )];
+        let yaml = metadata_to_yaml(&entries);
+        assert!(yaml.contains("nutrition:"));
+        assert!(yaml.contains("calories: 330 calories"));
+        assert!(yaml.contains("fat: 18 grams fat"));
+        // Should NOT be quoted as a single string
+        assert!(!yaml.contains("\""));
     }
 
     #[test]

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -19,12 +19,6 @@ pub fn sanitize_name(name: &str) -> String {
     name.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// Serialize a YAML scalar value using serde_yaml.
-pub fn yaml_escape(value: &str) -> String {
-    let yaml = serde_yaml::to_string(&value).unwrap_or_else(|_| value.to_string());
-    yaml.trim_end().to_string()
-}
-
 /// Build a YAML metadata string from a Recipe's fields.
 /// Handles nested values (e.g. nutrition) by parsing pre-formatted YAML blocks.
 pub fn metadata_to_yaml(entries: &[(String, String)]) -> String {
@@ -56,29 +50,6 @@ pub fn metadata_to_yaml(entries: &[(String, String)]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_yaml_escape_plain_value() {
-        assert_eq!(yaml_escape("hello world"), "hello world");
-    }
-
-    #[test]
-    fn test_yaml_escape_colon() {
-        assert_eq!(yaml_escape("test : sub"), "'test : sub'");
-    }
-
-    #[test]
-    fn test_yaml_escape_url() {
-        assert_eq!(
-            yaml_escape("http://example.com/recipe"),
-            "http://example.com/recipe"
-        );
-    }
-
-    #[test]
-    fn test_yaml_escape_hash() {
-        assert_eq!(yaml_escape("value # comment"), "'value # comment'");
-    }
 
     #[test]
     fn test_metadata_to_yaml_simple() {

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -18,3 +18,71 @@ pub struct RecipeComponents {
 pub fn sanitize_name(name: &str) -> String {
     name.split_whitespace().collect::<Vec<_>>().join(" ")
 }
+
+/// Escape a YAML value by wrapping it in double quotes if it contains
+/// characters that are special in YAML (e.g. `:`, `#`, `[`, `]`, `{`, `}`).
+pub fn yaml_escape(value: &str) -> String {
+    if value.contains(':')
+        || value.contains('#')
+        || value.contains('[')
+        || value.contains(']')
+        || value.contains('{')
+        || value.contains('}')
+        || value.contains('"')
+        || value.contains('\'')
+        || value.contains('*')
+        || value.contains('&')
+        || value.contains('!')
+        || value.contains('|')
+        || value.contains('>')
+        || value.contains('%')
+        || value.contains('@')
+        || value.contains('`')
+        || value.starts_with(' ')
+        || value.ends_with(' ')
+    {
+        // Escape existing double quotes and backslashes, then wrap
+        let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("\"{}\"", escaped)
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_yaml_escape_plain_value() {
+        assert_eq!(yaml_escape("hello world"), "hello world");
+    }
+
+    #[test]
+    fn test_yaml_escape_colon() {
+        assert_eq!(yaml_escape("test : sub"), "\"test : sub\"");
+    }
+
+    #[test]
+    fn test_yaml_escape_url() {
+        assert_eq!(
+            yaml_escape("http://example.com/recipe"),
+            "\"http://example.com/recipe\""
+        );
+    }
+
+    #[test]
+    fn test_yaml_escape_with_quotes() {
+        assert_eq!(yaml_escape("say \"hello\""), "\"say \\\"hello\\\"\"");
+    }
+
+    #[test]
+    fn test_yaml_escape_hash() {
+        assert_eq!(yaml_escape("value # comment"), "\"value # comment\"");
+    }
+
+    #[test]
+    fn test_sanitize_name() {
+        assert_eq!(sanitize_name("hello  world\n test"), "hello world test");
+    }
+}

--- a/src/pipelines/url.rs
+++ b/src/pipelines/url.rs
@@ -117,14 +117,14 @@ fn recipe_to_components(recipe: &crate::model::Recipe) -> RecipeComponents {
     // Build metadata YAML (without --- delimiters)
     let mut metadata_lines = Vec::new();
     if let Some(desc) = &recipe.description {
-        metadata_lines.push(format!("description: {}", desc));
+        metadata_lines.push(format!("description: {}", super::yaml_escape(desc)));
     }
     // Only use the first image if multiple are available
     if let Some(first_image) = recipe.image.first() {
-        metadata_lines.push(format!("image: {}", first_image));
+        metadata_lines.push(format!("image: {}", super::yaml_escape(first_image)));
     }
     for (key, value) in &recipe.metadata {
-        metadata_lines.push(format!("{}: {}", key, value));
+        metadata_lines.push(format!("{}: {}", key, super::yaml_escape(value)));
     }
 
     RecipeComponents {

--- a/src/pipelines/url.rs
+++ b/src/pipelines/url.rs
@@ -115,21 +115,21 @@ fn recipe_to_components(recipe: &crate::model::Recipe) -> RecipeComponents {
     text.push_str(recipe.instructions.trim_start());
 
     // Build metadata YAML (without --- delimiters)
-    let mut metadata_lines = Vec::new();
+    let mut entries = Vec::new();
     if let Some(desc) = &recipe.description {
-        metadata_lines.push(format!("description: {}", super::yaml_escape(desc)));
+        entries.push(("description".to_string(), desc.clone()));
     }
     // Only use the first image if multiple are available
     if let Some(first_image) = recipe.image.first() {
-        metadata_lines.push(format!("image: {}", super::yaml_escape(first_image)));
+        entries.push(("image".to_string(), first_image.clone()));
     }
     for (key, value) in &recipe.metadata {
-        metadata_lines.push(format!("{}: {}", key, super::yaml_escape(value)));
+        entries.push((key.clone(), value.clone()));
     }
 
     RecipeComponents {
         text,
-        metadata: metadata_lines.join("\n"),
+        metadata: super::metadata_to_yaml(&entries),
         name: super::sanitize_name(&recipe.name),
     }
 }

--- a/src/url_to_text/html/extractors/json_ld.rs
+++ b/src/url_to_text/html/extractors/json_ld.rs
@@ -353,11 +353,23 @@ struct JsonLdRecipe {
     #[serde(rename = "recipeYield")]
     recipe_yield: Option<RecipeYield>,
     /// Duration fields can be a string ("PT30M") or an object ({"@type": "Duration", ...})
-    #[serde(rename = "prepTime", deserialize_with = "deserialize_duration", default)]
+    #[serde(
+        rename = "prepTime",
+        deserialize_with = "deserialize_duration",
+        default
+    )]
     prep_time: Option<String>,
-    #[serde(rename = "cookTime", deserialize_with = "deserialize_duration", default)]
+    #[serde(
+        rename = "cookTime",
+        deserialize_with = "deserialize_duration",
+        default
+    )]
     cook_time: Option<String>,
-    #[serde(rename = "totalTime", deserialize_with = "deserialize_duration", default)]
+    #[serde(
+        rename = "totalTime",
+        deserialize_with = "deserialize_duration",
+        default
+    )]
     total_time: Option<String>,
     #[serde(rename = "suitableForDiet")]
     suitable_for_diet: Option<SuitableForDiet>,
@@ -778,10 +790,9 @@ fn is_recipe_type(value: &Value) -> bool {
         }
         // Handle @type as an array: "@type": ["Recipe"]
         if let Some(type_arr) = type_value.as_array() {
-            return type_arr.iter().any(|t| {
-                t.as_str()
-                    .map_or(false, |s| s.eq_ignore_ascii_case("recipe"))
-            });
+            return type_arr
+                .iter()
+                .any(|t| t.as_str().is_some_and(|s| s.eq_ignore_ascii_case("recipe")));
         }
     }
     false

--- a/src/url_to_text/text/extractor.rs
+++ b/src/url_to_text/text/extractor.rs
@@ -51,19 +51,15 @@ impl TextExtractor {
         let name = json["title"].as_str().unwrap_or("").to_string();
 
         // Build metadata YAML from available fields
-        let mut metadata_lines = vec![format!("source: {}", crate::pipelines::yaml_escape(source))];
+        let mut entries = vec![("source".to_string(), source.to_string())];
         for field in ["servings", "prep_time", "cook_time", "total_time"] {
             if let Some(val) = json[field].as_str() {
                 if !val.is_empty() {
-                    metadata_lines.push(format!(
-                        "{}: {}",
-                        field,
-                        crate::pipelines::yaml_escape(val)
-                    ));
+                    entries.push((field.to_string(), val.to_string()));
                 }
             }
         }
-        let metadata = metadata_lines.join("\n");
+        let metadata = crate::pipelines::metadata_to_yaml(&entries);
 
         // Format ingredients as newline-separated list
         let ingredients = json["ingredients"]
@@ -148,7 +144,7 @@ mod tests {
 
         assert_eq!(components.name, "Test Recipe");
         assert!(components.metadata.contains("source: test-source"));
-        assert!(components.metadata.contains("servings: 4"));
+        assert!(components.metadata.contains("servings: '4'"));
         assert!(components.metadata.contains("prep_time: 10 min"));
         assert!(components.metadata.contains("cook_time: 20 min"));
         assert!(components.metadata.contains("total_time: 30 min"));

--- a/src/url_to_text/text/extractor.rs
+++ b/src/url_to_text/text/extractor.rs
@@ -51,11 +51,11 @@ impl TextExtractor {
         let name = json["title"].as_str().unwrap_or("").to_string();
 
         // Build metadata YAML from available fields
-        let mut metadata_lines = vec![format!("source: {}", source)];
+        let mut metadata_lines = vec![format!("source: {}", crate::pipelines::yaml_escape(source))];
         for field in ["servings", "prep_time", "cook_time", "total_time"] {
             if let Some(val) = json[field].as_str() {
                 if !val.is_empty() {
-                    metadata_lines.push(format!("{}: {}", field, val));
+                    metadata_lines.push(format!("{}: {}", field, crate::pipelines::yaml_escape(val)));
                 }
             }
         }

--- a/src/url_to_text/text/extractor.rs
+++ b/src/url_to_text/text/extractor.rs
@@ -55,7 +55,11 @@ impl TextExtractor {
         for field in ["servings", "prep_time", "cook_time", "total_time"] {
             if let Some(val) = json[field].as_str() {
                 if !val.is_empty() {
-                    metadata_lines.push(format!("{}: {}", field, crate::pipelines::yaml_escape(val)));
+                    metadata_lines.push(format!(
+                        "{}: {}",
+                        field,
+                        crate::pipelines::yaml_escape(val)
+                    ));
                 }
             }
         }

--- a/tests/json_ld_metadata_test.rs
+++ b/tests/json_ld_metadata_test.rs
@@ -109,7 +109,7 @@ async fn test_metadata_with_numeric_yield() {
     let url = format!("{}/recipe", server.url());
     let result = url_to_recipe(&url).await.unwrap();
 
-    assert!(result.metadata.contains("servings: 4"));
+    assert!(result.metadata.contains("servings: '4'"));
 }
 
 #[tokio::test]

--- a/tests/test_author_id_only.rs
+++ b/tests/test_author_id_only.rs
@@ -96,7 +96,7 @@ async fn test_author_with_only_id() {
     assert!(result.metadata.contains("time required: 40 minutes"));
     assert!(result.metadata.contains("course: Salad, Side Dish"));
     assert!(result.metadata.contains("cuisine: American"));
-    assert!(result.metadata.contains("servings: 10"));
+    assert!(result.metadata.contains("servings: '10'"));
     assert!(result.metadata.contains(
         "tags: Barbecue, BLT pasta salad, Food for a Crowd, pasta, pasta salad, Potluck"
     ));

--- a/tests/test_case_insensitive_type.rs
+++ b/tests/test_case_insensitive_type.rs
@@ -90,7 +90,7 @@ async fn test_lowercase_recipe_type() {
     assert!(result.metadata.contains("prep time: 10 minutes"));
     assert!(result.metadata.contains("cook time: 30 minutes"));
     assert!(result.metadata.contains("time required: 40 minutes"));
-    assert!(result.metadata.contains("servings: 6"));
+    assert!(result.metadata.contains("servings: '6'"));
     assert!(result.metadata.contains("course: Soup"));
     assert!(result.metadata.contains("cuisine: Mexican"));
     assert!(result

--- a/tests/test_download_mode.rs
+++ b/tests/test_download_mode.rs
@@ -77,7 +77,7 @@ async fn test_download_mode_with_metadata() {
     assert!(stdout.contains("cuisine: Italian"));
     assert!(stdout.contains("servings: 4 servings"));
     assert!(stdout.contains("tags: test, recipe, metadata"));
-    assert!(stdout.contains(&format!("source: {}", url)));
+    assert!(stdout.contains(&format!("source: \"{}\"", url)));
     assert!(stdout.contains("title: Test Recipe"));
 
     // Check that content is included
@@ -121,7 +121,7 @@ async fn test_download_mode_without_metadata() {
 
     // Should still have frontmatter with at least the source URL and title
     assert!(stdout.contains("---\n"));
-    assert!(stdout.contains(&format!("source: {}", url)));
+    assert!(stdout.contains(&format!("source: \"{}\"", url)));
     assert!(stdout.contains("title: Simple Recipe"));
 
     // Check basic content

--- a/tests/test_download_mode.rs
+++ b/tests/test_download_mode.rs
@@ -77,7 +77,7 @@ async fn test_download_mode_with_metadata() {
     assert!(stdout.contains("cuisine: Italian"));
     assert!(stdout.contains("servings: 4 servings"));
     assert!(stdout.contains("tags: test, recipe, metadata"));
-    assert!(stdout.contains(&format!("source: \"{}\"", url)));
+    assert!(stdout.contains(&format!("source: {}", url)));
     assert!(stdout.contains("title: Test Recipe"));
 
     // Check that content is included
@@ -121,7 +121,7 @@ async fn test_download_mode_without_metadata() {
 
     // Should still have frontmatter with at least the source URL and title
     assert!(stdout.contains("---\n"));
-    assert!(stdout.contains(&format!("source: \"{}\"", url)));
+    assert!(stdout.contains(&format!("source: {}", url)));
     assert!(stdout.contains("title: Simple Recipe"));
 
     // Check basic content

--- a/tests/test_edge_cases.rs
+++ b/tests/test_edge_cases.rs
@@ -186,7 +186,7 @@ async fn test_recipe_yield_variations() {
 
     let url4 = format!("{}/recipe4", server.url());
     let result4 = url_to_recipe(&url4).await.unwrap();
-    assert!(result4.metadata.contains("servings: 6"));
+    assert!(result4.metadata.contains("servings: '6'"));
 }
 
 #[tokio::test]

--- a/tests/test_missing_ingredients.rs
+++ b/tests/test_missing_ingredients.rs
@@ -84,7 +84,7 @@ async fn test_recipe_without_ingredients() {
     assert!(result.metadata.contains("time required: 25 minutes"));
     assert!(result.metadata.contains("course: Main Course"));
     assert!(result.metadata.contains("cuisine: Indian"));
-    assert!(result.metadata.contains("servings: 2"));
+    assert!(result.metadata.contains("servings: '2'"));
 
     // Verify instructions were parsed
     assert!(result.text.contains("iron kadai"));

--- a/tests/test_no_instructions.rs
+++ b/tests/test_no_instructions.rs
@@ -83,7 +83,7 @@ async fn test_recipe_without_instructions() {
     assert!(result
         .metadata
         .contains("time required: 5 hours 30 minutes"));
-    assert!(result.metadata.contains("servings: 8"));
+    assert!(result.metadata.contains("servings: '8'"));
 }
 
 #[tokio::test]
@@ -195,7 +195,7 @@ async fn test_recipe_with_empty_ingredients_array() {
     assert!(result
         .metadata
         .contains("time required: 2 hours 30 minutes"));
-    assert!(result.metadata.contains("servings: 4"));
+    assert!(result.metadata.contains("servings: '4'"));
     assert!(result
         .metadata
         .contains("tags: Asiatiskt, Tillbehör, Grönsaker, Frukt"));


### PR DESCRIPTION
## Summary
- Fixes #48
- Added `yaml_escape()` helper that wraps YAML values in double quotes when they contain special characters (`:`, `#`, `[`, `]`, `{`, `}`, etc.)
- Applied escaping to all places that emit YAML frontmatter: `model.rs`, `lib.rs`, `builder.rs`, `url.rs`, and `extractor.rs`

## Test plan
- [x] Added unit tests for `yaml_escape()` covering plain values, colons, URLs, embedded quotes, and hash characters
- [x] Updated existing download mode tests to expect quoted URLs
- [x] All 107 tests pass