### PR TITLE
Fix conversion quality: numeric servings, prompt hardening, evaluator prompt

### DIFF
--- a/src/converters/eval_prompt.txt
+++ b/src/converters/eval_prompt.txt
@@ -1,0 +1,55 @@
+You are a Cooklang conversion quality reviewer. Your task is to judge how faithfully a Cooklang conversion reproduces the original recipe it was generated from.
+
+Here is the original recipe text:
+
+<original>
+{{ORIGINAL}}
+</original>
+
+Here is the Cooklang conversion to evaluate:
+
+<cooklang>
+{{COOKLANG}}
+</cooklang>
+
+Compare the conversion against the original on these dimensions:
+
+1. INGREDIENT COVERAGE - every ingredient in the original (including basics like salt, pepper, oil, and garnishes) appears as an @ingredient token. Ingredients mentioned in steps but never tagged with @ are misses.
+
+2. QUANTITY FIDELITY - quantities and units match the original exactly: no dropped fractions, no unit conversions, no collapsed ranges ("2-3" must stay "2-3"), no invented amounts for ingredients the original leaves unquantified.
+
+3. STEP FIDELITY - all instruction steps are present and in order. Nothing is dropped, merged away, or truncated. Nothing is invented: no fabricated steps, tips, or narrative that is not in the original.
+
+4. COOKLANG SYNTAX - proper @ingredient{qty%unit} tokens (% between quantity and unit), #cookware, ~timer{n%unit}, YAML frontmatter between --- delimiters (never the deprecated `>> key: value` syntax), valid YAML.
+
+5. METADATA - frontmatter title, servings, times, and source reflect the original. Servings is a plain number. Metadata values present in the source are not dropped and not fabricated.
+
+6. LANGUAGE - the output stays entirely in the original's language, including every ingredient token (in a German recipe @Salz{}, not @salt{}).
+
+COMMON ISSUES to check for explicitly (each of these has occurred in production):
+
+- Raw source text passed through with no Cooklang markup at all
+- Output describing a different dish than the original
+- Missing frontmatter or title even though the source provides one
+- Listed ingredients (especially salt, pepper, oil, garnishes) never tagged and silently dropped
+- The same ingredient tagged with a full quantity in more than one step, double-counting it in shopping lists (watch "divided" amounts)
+- Invented quantities for ingredients the original leaves unquantified ("a splash", "to taste")
+- Entire instruction sequences invented for input that only contained an ingredient list
+- Fabricated servings, prep/cook times, or nutrition not present in the source
+- Ingredient tokens translated to English inside a non-English recipe
+- Phantom @ tokens for non-ingredients: oven temperatures (@420F), intermediate mixtures (@dough, @batter, @cake), bare measurements (@200g)
+- Missing % separator between quantity and unit ({250 g}, {1/4 cup}) or garbled units
+- Timer ranges collapsed to a single endpoint, or natural units converted awkwardly (12 hours as 720 minutes)
+- The original ingredient list appended verbatim as a bogus final step
+- Recipe truncated before the final step
+
+Weigh issues by impact on a cook actually using the recipe: wrong or double-counted quantities, missing ingredients, invented content, and unusable structure are disqualifying; stylistic choices (unnamed timers, note phrasing, whether salt is scaling-locked) are not.
+
+Output only this JSON without any other characters:
+
+{
+  "verdict": "<good OR bad - good means faithful and usable, minor nits allowed; bad means missing/wrong ingredients or quantities, dropped or invented content, broken syntax, or output unusable as a recipe>",
+  "score": <integer 1-5, where 5 is a flawless conversion and 1 is unusable>,
+  "issues": ["<short description of each concrete issue found, with evidence from the texts; empty array if none>"],
+  "note": "<one-sentence summary of the conversion quality>"
+}

--- a/src/converters/evaluator.rs
+++ b/src/converters/evaluator.rs
@@ -1,0 +1,43 @@
+/// The prompt template used for evaluating the quality of a Cooklang conversion.
+///
+/// It instructs an LLM to compare a Cooklang conversion against the original
+/// recipe text across ingredient coverage, quantity fidelity, step fidelity,
+/// syntax, metadata, and language, and lists the failure modes observed in
+/// production conversions. The model returns a JSON object with a
+/// `good`/`bad` verdict, a 1-5 score, concrete issues, and a summary note —
+/// matching the review taxonomy used by the cook.md admin quality page.
+///
+/// The prompt is loaded from `eval_prompt.txt` at compile time and contains
+/// `{{ORIGINAL}}` and `{{COOKLANG}}` placeholders to be filled with
+/// [`inject_evaluation`].
+pub const COOKLANG_EVALUATOR_PROMPT: &str = include_str!("eval_prompt.txt");
+
+/// Injects the original recipe text and its Cooklang conversion into the
+/// evaluation prompt template.
+pub fn inject_evaluation(original_text: &str, cooklang: &str) -> String {
+    COOKLANG_EVALUATOR_PROMPT
+        .replace("{{ORIGINAL}}", original_text)
+        .replace("{{COOKLANG}}", cooklang)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prompt_is_embedded() {
+        assert!(!COOKLANG_EVALUATOR_PROMPT.is_empty());
+        assert!(COOKLANG_EVALUATOR_PROMPT.contains("INGREDIENT COVERAGE"));
+        assert!(COOKLANG_EVALUATOR_PROMPT.contains("COMMON ISSUES"));
+        assert!(COOKLANG_EVALUATOR_PROMPT.contains("verdict"));
+    }
+
+    #[test]
+    fn test_inject_evaluation() {
+        let filled = inject_evaluation("2 eggs\n\nBoil them.", "Boil @eggs{2}.");
+        assert!(filled.contains("2 eggs\n\nBoil them."));
+        assert!(filled.contains("Boil @eggs{2}."));
+        assert!(!filled.contains("{{ORIGINAL}}"));
+        assert!(!filled.contains("{{COOKLANG}}"));
+    }
+}

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -1,5 +1,6 @@
 mod anthropic;
 mod azure_openai;
+mod evaluator;
 mod google;
 mod ollama;
 mod open_ai;
@@ -10,6 +11,7 @@ pub use azure_openai::AzureOpenAiConverter;
 pub use google::GoogleConverter;
 pub use ollama::OllamaConverter;
 pub use open_ai::OpenAiConverter;
+pub use evaluator::{inject_evaluation, COOKLANG_EVALUATOR_PROMPT};
 pub use prompt::{inject_recipe, COOKLANG_CONVERTER_PROMPT};
 
 use async_trait::async_trait;

--- a/src/converters/mod.rs
+++ b/src/converters/mod.rs
@@ -8,10 +8,10 @@ mod prompt;
 
 pub use anthropic::AnthropicConverter;
 pub use azure_openai::AzureOpenAiConverter;
+pub use evaluator::{inject_evaluation, COOKLANG_EVALUATOR_PROMPT};
 pub use google::GoogleConverter;
 pub use ollama::OllamaConverter;
 pub use open_ai::OpenAiConverter;
-pub use evaluator::{inject_evaluation, COOKLANG_EVALUATOR_PROMPT};
 pub use prompt::{inject_recipe, COOKLANG_CONVERTER_PROMPT};
 
 use async_trait::async_trait;

--- a/src/converters/prompt.txt
+++ b/src/converters/prompt.txt
@@ -21,7 +21,8 @@ Use the @ symbol to define ingredients. Always close with curly braces, even for
 - Optional ingredients. Mark the ingredient as optional with @?: Now you can add @?hash browns{3-4}. Always close with curly braces: @?boba{} not @?boba.
 - The quantity and unit inside braces MUST be separated by % with no spaces: @flour{200%g}, never @flour{200 g} or @flour{200g}.
 - Quantity ranges keep the range: "2-3 cloves garlic" → @garlic{2-3%cloves}. Do NOT collapse ranges to a single number.
-- NEVER modify ingredient amounts from the original recipe (e.g., "3 tbsp oats" stays as @oats{3%tbsp}).
+- NEVER modify ingredient amounts or units from the original recipe (e.g., "3 tbsp oats" stays as @oats{3%tbsp}). Do NOT convert units: "12 g salt" stays @salt{12%g}, never @salt{1%tsp}.
+- The token REPLACES the original words - never write the ingredient name both as plain text and as a token: "add the ziti pasta" → "add the @ziti pasta{}", NOT "add the ziti pasta @ziti pasta{}".
 - NEVER invent an amount the original does not give. Unquantified ingredients get empty braces: "a splash of water" → a splash of @water{}, "salt to taste" → @salt{} to taste.
 - Tag each ingredient's quantity EXACTLY ONCE - at its first use. If the same ingredient appears again later, write it as plain text (or @name{} with empty braces when tagging helps). Repeating the quantity double-counts the ingredient in shopping lists. For divided amounts ("1 cup sugar, divided"), split the real amounts across the steps where they are used so they sum to the original total.
 - Only tag real ingredients. NEVER create @ tokens for oven temperatures (@180C), equipment, intermediate mixtures (@dough, @batter, @cake), or bare measurements (@200g).
@@ -33,6 +34,7 @@ Use the # symbol to define cookware. Always close with curly braces, even for si
 - Multi-word: #potato masher{} or #baking sheet{}
 - Include size/descriptors as part of the cookware name: "#9.5-10-inch stainless steel pan{}" or "#small saucepan{}" (NOT "small #saucepan{}" or "9.5-10-inch #stainless steel pan{}")
 - Do NOT tag common kitchen items like bowls, plates, knives, spoons, forks, cutting boards.
+- The token REPLACES the original words - never write the cookware name both as plain text and as a token: "heat a skillet" → "heat a #skillet{}", NOT "heat a skillet #skillet{}".
 
 TIMERS
 Use the ~ symbol to define timers. Always close with curly braces. Format must be ~{number%units} or ~name{number%units}. Convert all durations to a single unit.
@@ -52,7 +54,7 @@ STEPS
 Each paragraph is a cooking step. Steps must be separated by an empty line (two newlines). Limit lines to 80-100 characters when practical.
 
 SECTIONS
-For recipes with multiple components, use section headers. Do NOT use sections if the recipe has only one component.
+For recipes with multiple components, use section headers. Do NOT use sections if the recipe has only one component. Only use section names the original recipe actually has - NEVER invent a section header as a title for the recipe (no "== Pasta Dish ==" wrapping the whole recipe).
 == Section Name ==
 
 Example:

--- a/src/converters/prompt.txt
+++ b/src/converters/prompt.txt
@@ -18,9 +18,14 @@ Use the @ symbol to define ingredients. Always close with curly braces, even for
 - With quantity and unit: @bacon strips{1%kg} or @syrup{1/2%tbsp} or @potato{1%large} or @chopped tomatoes{1%12oz can} or @salt{pinch} or @edamame pods{1%28oz frozen package} or @chickpeas{1%400g can}
 - Fixed quantities (don't scale with servings): @salt{=1%tsp}
 - With preparation instructions: @onion{1}(peeled and finely chopped) or @garlic{2%cloves}(minced). Note that there shouldn't be any white space between }(.
-- Optional ingredients. Mark the ingredient as optional with @?: Now you can add @?hash browns{3-4}
+- Optional ingredients. Mark the ingredient as optional with @?: Now you can add @?hash browns{3-4}. Always close with curly braces: @?boba{} not @?boba.
+- The quantity and unit inside braces MUST be separated by % with no spaces: @flour{200%g}, never @flour{200 g} or @flour{200g}.
+- Quantity ranges keep the range: "2-3 cloves garlic" → @garlic{2-3%cloves}. Do NOT collapse ranges to a single number.
 - NEVER modify ingredient amounts from the original recipe (e.g., "3 tbsp oats" stays as @oats{3%tbsp}).
-- IMPORTANT: keep ingredients in {{LANGUAGE}}. Do not translate in other languages.
+- NEVER invent an amount the original does not give. Unquantified ingredients get empty braces: "a splash of water" → a splash of @water{}, "salt to taste" → @salt{} to taste.
+- Tag each ingredient's quantity EXACTLY ONCE - at its first use. If the same ingredient appears again later, write it as plain text (or @name{} with empty braces when tagging helps). Repeating the quantity double-counts the ingredient in shopping lists. For divided amounts ("1 cup sugar, divided"), split the real amounts across the steps where they are used so they sum to the original total.
+- Only tag real ingredients. NEVER create @ tokens for oven temperatures (@180C), equipment, intermediate mixtures (@dough, @batter, @cake), or bare measurements (@200g).
+- IMPORTANT: keep ingredients in {{LANGUAGE}}. Do not translate in other languages. This applies to EVERY ingredient token including salt, pepper, oil and other basics - in a German recipe write @Salz{}, not @salt{}.
 
 COOKWARE
 Use the # symbol to define cookware. Always close with curly braces, even for single-word items. Only tag cookware the FIRST time it appears in the recipe.
@@ -33,8 +38,9 @@ TIMERS
 Use the ~ symbol to define timers. Always close with curly braces. Format must be ~{number%units} or ~name{number%units}. Convert all durations to a single unit.
 - Basic timer: ~{25%minutes}
 - Named timer: ~eggs{3%minutes}
-- With ranges: ~{10-15%minutes} (use "-" for ranges, single unit)
-- Convert complex durations to single unit:
+- With ranges: ~{10-15%minutes} (use "-" for ranges, single unit). Keep ranges as ranges - do NOT collapse "10-15 minutes" to a single number.
+- Keep the original's unit when it is already single: "12 hours" → ~{12%hours}, not ~{720%minutes}.
+- Convert mixed durations to a single unit:
   - "1 hour 45 minutes" → ~{105%minutes}
   - "4:00 minutes" → ~{4%minutes}
   - "1¼ hours" → ~{75%minutes}
@@ -70,9 +76,9 @@ CONVERSION GUIDELINES:
 
 IMPORTANT: Do NOT include a title or header in your output. Start directly with the recipe steps or sections.
 
-1. Remove the original ingredient list entirely. Incorporate each ingredient into the method text using Cooklang syntax.
+1. Remove the original ingredient list entirely. Incorporate each ingredient into the method text using Cooklang syntax. EVERY ingredient from the original list must appear as an @ token somewhere in the output - including basics like salt, pepper, oil, and garnishes. Never drop an ingredient. Do NOT append the ingredient list as an extra step at the end.
 
-2. Preserve the original recipe's wording as much as possible. Only modify text to add Cooklang markup symbols (@, #, ~).
+2. Preserve the original recipe's wording as much as possible. Only modify text to add Cooklang markup symbols (@, #, ~). Never add steps, tips, or details that are not in the original, and never reorder steps.
 
 3. Preserve preparation instructions (like "chopped", "diced", "peeled") using the short-hand preparation syntax with parentheses: @onion{1}(diced)
 
@@ -90,7 +96,7 @@ IMPORTANT: Do NOT include a title or header in your output. Start directly with 
 
 10. When a timer is mentioned, mark it with ~ and include the duration.
 
-11. If the input contains no cooking steps or method, output "no recipe" instead of trying to create one.
+11. If the input contains no cooking steps or method (e.g. only an ingredient list), output "no recipe" instead of trying to create one. NEVER invent cooking instructions that are not in the input.
 
 12. Replace tilde (~) used for approximations with the word "about" - only use ~ for timers. Example: "~500 grams" becomes "about 500 grams", "~20cm/8\"" becomes "about 20cm/8\"".
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,7 @@ pub use uniffi_bindings::*;
 // Public API re-exports
 pub use config::AiConfig;
 pub use converters::{
-    inject_evaluation, ConversionMetadata, ConversionResult, TokenUsage,
-    COOKLANG_EVALUATOR_PROMPT,
+    inject_evaluation, ConversionMetadata, ConversionResult, TokenUsage, COOKLANG_EVALUATOR_PROMPT,
 };
 pub use error::ImportError;
 pub use images_to_text::ImageSource;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,10 @@ pub use uniffi_bindings::*;
 
 // Public API re-exports
 pub use config::AiConfig;
-pub use converters::{ConversionMetadata, ConversionResult, TokenUsage};
+pub use converters::{
+    inject_evaluation, ConversionMetadata, ConversionResult, TokenUsage,
+    COOKLANG_EVALUATOR_PROMPT,
+};
 pub use error::ImportError;
 pub use images_to_text::ImageSource;
 pub use pipelines::RecipeComponents;

--- a/src/model.rs
+++ b/src/model.rs
@@ -29,7 +29,13 @@ impl Recipe {
             entries.push(("__image__".to_string(), self.image.join(", ")));
         }
         for (key, value) in &self.metadata {
-            entries.push((key.clone(), value.clone()));
+            if key == "servings" {
+                // Reduce free-form yields to a numeric servings value; the
+                // original text is kept under `yield`.
+                entries.extend(crate::pipelines::servings_entries(value));
+            } else {
+                entries.push((key.clone(), value.clone()));
+            }
         }
 
         // YAML frontmatter

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -19,6 +19,40 @@ pub fn sanitize_name(name: &str) -> String {
     name.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+/// Extract the first integer from a free-form yield string ("Makes 12", "4 personnes").
+/// The Cooklang parser only accepts numeric `servings`, so descriptive yields must be
+/// reduced to a number (callers keep the original text under a `yield` key).
+pub fn extract_servings_number(raw: &str) -> Option<u32> {
+    let digits: String = raw
+        .chars()
+        .skip_while(|c| !c.is_ascii_digit())
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}
+
+/// Normalize a raw yield value into metadata entries: a numeric `servings` when a
+/// number can be extracted, plus the original text as `yield` when it carries more
+/// information than the bare number.
+pub fn servings_entries(raw: &str) -> Vec<(String, String)> {
+    let raw = raw.trim();
+    let mut entries = Vec::new();
+    match extract_servings_number(raw) {
+        Some(n) => {
+            entries.push(("servings".to_string(), n.to_string()));
+            if raw != n.to_string() {
+                entries.push(("yield".to_string(), raw.to_string()));
+            }
+        }
+        None => {
+            if !raw.is_empty() {
+                entries.push(("yield".to_string(), raw.to_string()));
+            }
+        }
+    }
+    entries
+}
+
 /// Build a YAML metadata string from a Recipe's fields.
 /// Handles nested values (e.g. nutrition) by parsing pre-formatted YAML blocks.
 pub fn metadata_to_yaml(entries: &[(String, String)]) -> String {
@@ -34,6 +68,14 @@ pub fn metadata_to_yaml(entries: &[(String, String)]) -> String {
                 for (k, v) in parsed {
                     mapping.insert(k, v);
                 }
+                continue;
+            }
+        }
+        // The Cooklang parser rejects quoted numbers for `servings` — emit it as a
+        // YAML number so `servings: 4` parses instead of warning on `servings: '4'`.
+        if key == "servings" {
+            if let Ok(n) = value.trim().parse::<u64>() {
+                mapping.insert(Value::String(key.clone()), Value::Number(n.into()));
                 continue;
             }
         }
@@ -59,7 +101,45 @@ mod tests {
         ];
         let yaml = metadata_to_yaml(&entries);
         assert!(yaml.contains("source: http://example.com"));
-        assert!(yaml.contains("servings: '4'"));
+        // servings must be a bare YAML number — the Cooklang parser rejects '4'
+        assert!(yaml.contains("servings: 4"));
+        assert!(!yaml.contains("servings: '4'"));
+    }
+
+    #[test]
+    fn test_extract_servings_number() {
+        assert_eq!(extract_servings_number("4"), Some(4));
+        assert_eq!(extract_servings_number("Makes 12"), Some(12));
+        assert_eq!(extract_servings_number("4 personnes"), Some(4));
+        assert_eq!(extract_servings_number("4 to 6 servings"), Some(4));
+        assert_eq!(extract_servings_number("a few"), None);
+    }
+
+    #[test]
+    fn test_servings_entries_numeric_only() {
+        assert_eq!(
+            servings_entries("4"),
+            vec![("servings".to_string(), "4".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_servings_entries_descriptive() {
+        assert_eq!(
+            servings_entries("Makes 12"),
+            vec![
+                ("servings".to_string(), "12".to_string()),
+                ("yield".to_string(), "Makes 12".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_servings_entries_no_number() {
+        assert_eq!(
+            servings_entries("one loaf-ish"),
+            vec![("yield".to_string(), "one loaf-ish".to_string())]
+        );
     }
 
     #[test]

--- a/src/pipelines/url.rs
+++ b/src/pipelines/url.rs
@@ -124,7 +124,13 @@ fn recipe_to_components(recipe: &crate::model::Recipe) -> RecipeComponents {
         entries.push(("image".to_string(), first_image.clone()));
     }
     for (key, value) in &recipe.metadata {
-        entries.push((key.clone(), value.clone()));
+        if key == "servings" {
+            // Reduce free-form yields ("Makes 12", "4 personnes") to a numeric
+            // servings value; the original text is kept under `yield`.
+            entries.extend(super::servings_entries(value));
+        } else {
+            entries.push((key.clone(), value.clone()));
+        }
     }
 
     RecipeComponents {

--- a/src/url_to_text/text/extractor.rs
+++ b/src/url_to_text/text/extractor.rs
@@ -10,6 +10,10 @@ Sometimes the text is not a recipe - in that case specify that in the error fiel
 
 IMPORTANT: Only extract information that is EXPLICITLY present in the text. Do NOT invent, guess, or estimate any values. If a field is not mentioned in the text, use null.
 
+IMPORTANT: Keep the recipe's original language. Copy ingredients and instructions verbatim - never translate, paraphrase, or add wording of your own.
+
+If the text contains only an ingredient list with no cooking instructions, return the ingredients and an empty instructions array - do NOT invent instructions.
+
 Given the text, output only this JSON without any other characters:
 
 {
@@ -50,12 +54,20 @@ impl TextExtractor {
         // Extract title (fallback to empty string)
         let name = json["title"].as_str().unwrap_or("").to_string();
 
-        // Build metadata YAML from available fields
+        // Build metadata YAML from available fields, mapping the extractor's JSON
+        // field names to canonical Cooklang metadata keys.
         let mut entries = vec![("source".to_string(), source.to_string())];
-        for field in ["servings", "prep_time", "cook_time", "total_time"] {
+        if let Some(val) = json["servings"].as_str() {
+            entries.extend(crate::pipelines::servings_entries(val));
+        }
+        for (field, key) in [
+            ("prep_time", "prep time"),
+            ("cook_time", "cook time"),
+            ("total_time", "time required"),
+        ] {
             if let Some(val) = json[field].as_str() {
                 if !val.is_empty() {
-                    entries.push((field.to_string(), val.to_string()));
+                    entries.push((key.to_string(), val.to_string()));
                 }
             }
         }
@@ -112,6 +124,7 @@ async fn fetch_json(texts: String) -> Result<Value, Box<dyn Error + Send + Sync>
         .header("Authorization", format!("Bearer {api_key}"))
         .json(&serde_json::json!({
             "model": MODEL,
+            "response_format": { "type": "json_object" },
             "messages": [
                 { "role": "system", "content": PROMPT },
                 { "role": "user", "content": texts }
@@ -122,9 +135,16 @@ async fn fetch_json(texts: String) -> Result<Value, Box<dyn Error + Send + Sync>
         .json::<Value>()
         .await?;
 
-    let content = response["choices"][0]["message"]["content"]
-        .as_str()
-        .ok_or("Failed to get response content")?;
+    let content = match response["choices"][0]["message"]["content"].as_str() {
+        Some(content) => content,
+        None => {
+            // Surface the API's own error message instead of a generic failure
+            let detail = response["error"]["message"]
+                .as_str()
+                .unwrap_or("no content in response");
+            return Err(format!("Failed to get response content: {}", detail).into());
+        }
+    };
 
     serde_json::from_str(content).map_err(|e| e.into())
 }
@@ -144,10 +164,10 @@ mod tests {
 
         assert_eq!(components.name, "Test Recipe");
         assert!(components.metadata.contains("source: test-source"));
-        assert!(components.metadata.contains("servings: '4'"));
-        assert!(components.metadata.contains("prep_time: 10 min"));
-        assert!(components.metadata.contains("cook_time: 20 min"));
-        assert!(components.metadata.contains("total_time: 30 min"));
+        assert!(components.metadata.contains("servings: 4"));
+        assert!(components.metadata.contains("prep time: 10 min"));
+        assert!(components.metadata.contains("cook time: 20 min"));
+        assert!(components.metadata.contains("time required: 30 min"));
         assert!(components.text.contains("pasta"));
         assert!(components.text.contains("sauce"));
         assert!(components.text.contains("Cook pasta with sauce"));

--- a/tests/json_ld_metadata_test.rs
+++ b/tests/json_ld_metadata_test.rs
@@ -72,7 +72,9 @@ async fn test_comprehensive_metadata_extraction() {
     assert!(result.metadata.contains("prep time: 30 minutes"));
     assert!(result.metadata.contains("cook time: 45 minutes"));
     assert!(result.metadata.contains("time required: 1 hour 15 minutes"));
-    assert!(result.metadata.contains("servings: 12 servings"));
+    // Descriptive yield is reduced to numeric servings, original kept as yield
+    assert!(result.metadata.contains("servings: 12"));
+    assert!(result.metadata.contains("yield: 12 servings"));
     assert!(result.metadata.contains("course: Dessert"));
     assert!(result.metadata.contains("cuisine: French"));
     assert!(result.metadata.contains("diet: GlutenFree, Vegetarian"));
@@ -109,7 +111,10 @@ async fn test_metadata_with_numeric_yield() {
     let url = format!("{}/recipe", server.url());
     let result = url_to_recipe(&url).await.unwrap();
 
-    assert!(result.metadata.contains("servings: '4'"));
+    // Numeric servings must stay a bare YAML number (the Cooklang parser
+    // warns on quoted strings like servings: '4')
+    assert!(result.metadata.contains("servings: 4"));
+    assert!(!result.metadata.contains("servings: '4'"));
 }
 
 #[tokio::test]

--- a/tests/test_author_id_only.rs
+++ b/tests/test_author_id_only.rs
@@ -96,7 +96,7 @@ async fn test_author_with_only_id() {
     assert!(result.metadata.contains("time required: 40 minutes"));
     assert!(result.metadata.contains("course: Salad, Side Dish"));
     assert!(result.metadata.contains("cuisine: American"));
-    assert!(result.metadata.contains("servings: '10'"));
+    assert!(result.metadata.contains("servings: 10"));
     assert!(result.metadata.contains(
         "tags: Barbecue, BLT pasta salad, Food for a Crowd, pasta, pasta salad, Potluck"
     ));

--- a/tests/test_case_insensitive_type.rs
+++ b/tests/test_case_insensitive_type.rs
@@ -90,7 +90,7 @@ async fn test_lowercase_recipe_type() {
     assert!(result.metadata.contains("prep time: 10 minutes"));
     assert!(result.metadata.contains("cook time: 30 minutes"));
     assert!(result.metadata.contains("time required: 40 minutes"));
-    assert!(result.metadata.contains("servings: '6'"));
+    assert!(result.metadata.contains("servings: 6"));
     assert!(result.metadata.contains("course: Soup"));
     assert!(result.metadata.contains("cuisine: Mexican"));
     assert!(result

--- a/tests/test_download_mode.rs
+++ b/tests/test_download_mode.rs
@@ -75,7 +75,8 @@ async fn test_download_mode_with_metadata() {
     assert!(stdout.contains("time required: 45 minutes"));
     assert!(stdout.contains("course: Main Course"));
     assert!(stdout.contains("cuisine: Italian"));
-    assert!(stdout.contains("servings: 4 servings"));
+    assert!(stdout.contains("servings: 4"));
+    assert!(stdout.contains("yield: 4 servings"));
     assert!(stdout.contains("tags: test, recipe, metadata"));
     assert!(stdout.contains(&format!("source: {}", url)));
     assert!(stdout.contains("title: Test Recipe"));

--- a/tests/test_edge_cases.rs
+++ b/tests/test_edge_cases.rs
@@ -138,7 +138,8 @@ async fn test_recipe_yield_variations() {
 
     let url1 = format!("{}/recipe1", server.url());
     let result1 = url_to_recipe(&url1).await.unwrap();
-    assert!(result1.metadata.contains("servings: 15 Stück"));
+    assert!(result1.metadata.contains("servings: 15"));
+    assert!(result1.metadata.contains("yield: 15 Stück"));
 
     // Test 2: Simple string yield
     let json_ld = r#"
@@ -162,7 +163,8 @@ async fn test_recipe_yield_variations() {
 
     let url3 = format!("{}/recipe3", server.url());
     let result3 = url_to_recipe(&url3).await.unwrap();
-    assert!(result3.metadata.contains("servings: 8 portions"));
+    assert!(result3.metadata.contains("servings: 8"));
+    assert!(result3.metadata.contains("yield: 8 portions"));
 
     // Test 3: Numeric yield
     let json_ld = r#"
@@ -186,7 +188,7 @@ async fn test_recipe_yield_variations() {
 
     let url4 = format!("{}/recipe4", server.url());
     let result4 = url_to_recipe(&url4).await.unwrap();
-    assert!(result4.metadata.contains("servings: '6'"));
+    assert!(result4.metadata.contains("servings: 6"));
 }
 
 #[tokio::test]

--- a/tests/test_german_recipe.rs
+++ b/tests/test_german_recipe.rs
@@ -113,7 +113,8 @@ async fn test_german_recipe_with_sections_and_array_yield() {
     );
 
     // Check that yield array was handled correctly - should prefer "15 Stück" over "15"
-    assert!(result.metadata.contains("servings: 15 Stück"));
+    assert!(result.metadata.contains("servings: 15"));
+    assert!(result.metadata.contains("yield: 15 Stück"));
 
     // Check that category array was handled
     assert!(result.metadata.contains("course: Dessert, Kuchen, Snack"));
@@ -183,5 +184,6 @@ async fn test_recipe_yield_variations() {
     let result = url_to_recipe(&url).await.unwrap();
 
     // Should pick "4 servings" because it contains alphabetic characters
-    assert!(result.metadata.contains("servings: 4 servings"));
+    assert!(result.metadata.contains("servings: 4"));
+    assert!(result.metadata.contains("yield: 4 servings"));
 }

--- a/tests/test_missing_ingredients.rs
+++ b/tests/test_missing_ingredients.rs
@@ -84,7 +84,7 @@ async fn test_recipe_without_ingredients() {
     assert!(result.metadata.contains("time required: 25 minutes"));
     assert!(result.metadata.contains("course: Main Course"));
     assert!(result.metadata.contains("cuisine: Indian"));
-    assert!(result.metadata.contains("servings: '2'"));
+    assert!(result.metadata.contains("servings: 2"));
 
     // Verify instructions were parsed
     assert!(result.text.contains("iron kadai"));
@@ -209,7 +209,8 @@ async fn test_recipe_with_ingredient_objects() {
     // Verify metadata
     assert!(result.metadata.contains("author: Nigella Lawson"));
     assert!(result.metadata.contains("cuisine: Spanish"));
-    assert!(result.metadata.contains("servings: Gives 8-12 slices"));
+    assert!(result.metadata.contains("servings: 8"));
+    assert!(result.metadata.contains("yield: Gives 8-12 slices"));
 
     // Empty category array should not create metadata
     assert!(!result.metadata.contains("course:"));
@@ -286,7 +287,8 @@ async fn test_recipe_with_nested_sections() {
     // Verify metadata
     assert!(result.metadata.contains("course: Brokuły"));
     assert!(result.metadata.contains("cuisine: Kuchnia polska"));
-    assert!(result.metadata.contains("servings: 1 - 2"));
+    assert!(result.metadata.contains("servings: 1"));
+    assert!(result.metadata.contains("yield: 1 - 2"));
     assert!(result.metadata.contains("time required: 15 minutes"));
 }
 

--- a/tests/test_no_instructions.rs
+++ b/tests/test_no_instructions.rs
@@ -83,7 +83,7 @@ async fn test_recipe_without_instructions() {
     assert!(result
         .metadata
         .contains("time required: 5 hours 30 minutes"));
-    assert!(result.metadata.contains("servings: '8'"));
+    assert!(result.metadata.contains("servings: 8"));
 }
 
 #[tokio::test]
@@ -195,7 +195,7 @@ async fn test_recipe_with_empty_ingredients_array() {
     assert!(result
         .metadata
         .contains("time required: 2 hours 30 minutes"));
-    assert!(result.metadata.contains("servings: '4'"));
+    assert!(result.metadata.contains("servings: 4"));
     assert!(result
         .metadata
         .contains("tags: Asiatiskt, Tillbehör, Grönsaker, Frukt"));


### PR DESCRIPTION
## Summary

Fixes from a quality review of production cookifications (Jul 23-30, 413 records: mechanical validation of all 383 convertible records + LLM fidelity review of a 72-record stratified sample).

- **Numeric servings + canonical time keys** — the Cooklang parser rejects quoted/descriptive servings values, which warned in ~80% of converted recipes and broke scaling. `metadata_to_yaml` now emits `servings` as a bare YAML number; free-form yields ("Makes 12", "4 personnes") are reduced to the leading number with the original preserved under `yield`. The LLM text extractor emits `prep time`/`cook time`/`time required` instead of snake_case keys, pins JSON response format, keeps the source language, refuses to invent instructions, and surfaces real OpenAI error details instead of "Failed to get response content".
- **Converter prompt hardening** — explicit rules against the recurring defects found in review: double-tokenized quantities (8/72 sampled recipes double-counted ingredients), invented amounts, fabricated instructions for ingredient-only input, English tokens in non-English recipes (15/72), phantom tokens for temperatures/intermediate mixtures, missing `%` separators, and collapsed ranges.
- **New evaluator prompt in the library** — `eval_prompt.txt` + `inject_evaluation`/`COOKLANG_EVALUATOR_PROMPT`: compares a conversion against its original, lists the production failure modes explicitly, and returns `good`/`bad` + score + issues + note matching the cook.md admin review taxonomy.

## Test plan

- `cargo test` — full suite green (existing assertions updated for the numeric-servings format)
- Verified against `cookcli` parser: `servings: 4` parses clean, `servings: '4'` and descriptive strings warn