### PR TITLE
Builder: fall back to shared default temperature

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -428,7 +428,10 @@ impl RecipeImporterBuilder {
                     .map(|c| c.model.clone())
                     .unwrap_or_else(|| default_model_for_provider(provider_name).to_string())
             }),
-            temperature: base_config.as_ref().map(|c| c.temperature).unwrap_or(0.7),
+            temperature: base_config
+                .as_ref()
+                .map(|c| c.temperature)
+                .unwrap_or_else(crate::config::default_temperature),
             max_tokens: base_config.as_ref().map(|c| c.max_tokens).unwrap_or(4000),
             api_key: self
                 .api_key

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,7 +126,7 @@ fn default_provider() -> String {
     "open_ai".to_string()
 }
 
-fn default_temperature() -> f32 {
+pub(crate) fn default_temperature() -> f32 {
     // Recipe conversion is a deterministic transformation; higher temperatures
     // measurably increase run-to-run variance (dropped notes/steps, reshaped
     // tokens) on the same input.


### PR DESCRIPTION
## Summary

Follow-up to #51: `build_provider_config` hardcoded `unwrap_or(0.7)` for the no-config-file case — which is exactly the path cells takes in production (its `config.toml` only has `[page_scriber]`). So the 0.2 default from #51 never reached production. The fallback now routes through `config::default_temperature()` so every path agrees; per-provider config overrides still work.

## Test plan
- `cargo test` green, clippy clean